### PR TITLE
Enable Discussions on woodland-generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ The billing account ID is required but not committed. Create a local vars file
 (already gitignored) or export an environment variable:
 
 ```bash
-# Option A — local tfvars file (gitignored)
+# Option A — local tfvars file (gitignored, auto-loaded by terraform)
 echo 'billing_account_id = "00E1AD-4FD6FE-852B90"' \
-  > terraform/alunduil/terraform.local.tfvars
+  > terraform/alunduil/terraform.local.auto.tfvars
 
 # Option B — environment variable
 export TF_VAR_billing_account_id="00E1AD-4FD6FE-852B90"
@@ -104,12 +104,13 @@ automatically on the next plan/apply.
 ### 5. Review and apply
 
 ```bash
-# Using a local tfvars file:
-terraform plan -var-file=terraform.local.tfvars
-
+terraform plan
 # Review the plan, then apply:
-terraform apply -var-file=terraform.local.tfvars
+terraform apply
 ```
+
+`terraform.local.auto.tfvars` (or `TF_VAR_billing_account_id`) is picked
+up automatically — no `-var-file=` needed.
 
 ## Day-to-day workflow
 
@@ -121,7 +122,7 @@ terraform apply -var-file=terraform.local.tfvars
    ```bash
    cd terraform/alunduil
    terraform init
-   terraform plan -var-file=terraform.local.tfvars -out=tfplan
+   terraform plan -out=tfplan
    terraform apply tfplan
    ```
 

--- a/terraform/alunduil/terraform.tfvars
+++ b/terraform/alunduil/terraform.tfvars
@@ -163,9 +163,10 @@ repositories = {
   }
 
   "woodland-generators" = {
-    description    = "A CLI tool for generating resources for Root: The Tabletop RPG."
-    classification = "default"
-    topics         = ["cli", "generator", "root", "rpg", "tabletop"]
+    description     = "A CLI tool for generating resources for Root: The Tabletop RPG."
+    classification  = "default"
+    topics          = ["cli", "generator", "root", "rpg", "tabletop"]
+    has_discussions = true
   }
 
   "zfs-replicate" = {


### PR DESCRIPTION
## Summary

\`woodland-generators\` now has a working Discussions tab — closes #4. Also flips the local var-file workflow so \`terraform plan\`/\`apply\` need no flags: rename \`terraform.local.tfvars\` → \`terraform.local.auto.tfvars\` (still gitignored) and update README accordingly.

## Gotchas

If you already have a \`terraform.local.tfvars\` checked out locally, rename it to \`terraform.local.auto.tfvars\` after pulling — Terraform won't auto-load the old name.