### PR TITLE
Configure Renovate for dependency updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # GCP credentials
 *.json
 !*example*.json
+!renovate.json
 
 # OS
 .DS_Store

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -26,3 +26,10 @@ path = ".devcontainer/devcontainer.json"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2026 Alex Brandt <alunduil@gmail.com>"
 SPDX-License-Identifier = "MIT"
+
+# JSON config files — JSON does not permit comments for inline headers
+[[annotations]]
+path = "renovate.json"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Alex Brandt <alunduil@gmail.com>"
+SPDX-License-Identifier = "MIT"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:best-practices"],
+  "baseBranchPatterns": ["main"],
+  "reviewers": ["alunduil"],
+  "pre-commit": {
+    "enabled": true
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.devcontainer/.*\\.sh$/"],
+      "matchStrings": ["pipx install reuse==(?<currentValue>[\\d.]+)"],
+      "depNameTemplate": "reuse",
+      "datasourceTemplate": "pypi"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
+      "matchStrings": ["terraform_version:\\s*['\"]?(?<currentValue>[\\d.]+)['\"]?"],
+      "depNameTemplate": "hashicorp/terraform",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)$"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["reuse", "fsfe/reuse-tool"],
+      "groupName": "reuse"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Renovate now manages dependency updates on this repo: GitHub Actions, Terraform providers, the Terraform lock file, pre-commit hook revs, and two custom-tracked pins (the `pipx install reuse==…` line in the devcontainer setup script and the `terraform_version` pin in the CI workflow). The next Renovate run will open the onboarding/dependency-dashboard issue.

## Gotchas

- `config:best-practices` brings `helpers:pinGitHubActionDigests`, so expect early PRs that pin `actions/checkout@v6` etc. to a SHA with a comment — that is intentional.
- The `*.json` rule in `.gitignore` exists for stray GCP credential files; I added `!renovate.json` rather than reorganise the rule so the credential safety net stays intact.
- The Terraform `extractVersionTemplate` strips the leading `v` from upstream tags so the bare `1.9.0` style in the workflow keeps matching.
- Reviewer-pings only fire once Renovate is enabled in the GitHub App settings; nothing in this PR enables the app itself.

## Verification

- `pre-commit run --files renovate.json REUSE.toml .gitignore` — all hooks passed (terraform/yaml/markdown skipped, no matching files).
- `renovate-config-validator --no-global --strict renovate.json` — `Config validated successfully` as a repo config.