### PR TITLE
Manage default branch and protection in Terraform

### DIFF
--- a/terraform/alunduil/locals.tf
+++ b/terraform/alunduil/locals.tf
@@ -19,6 +19,7 @@ locals {
     delete_branch_on_merge      = true
     vulnerability_alerts        = true
     archive_on_destroy          = true
+    default_branch              = "main"
   }
 
   classification_overrides = {
@@ -52,6 +53,7 @@ locals {
       delete_branch_on_merge      = repo.delete_branch_on_merge != null ? repo.delete_branch_on_merge : local.classification_settings[repo.classification].delete_branch_on_merge
       vulnerability_alerts        = repo.vulnerability_alerts != null ? repo.vulnerability_alerts : local.classification_settings[repo.classification].vulnerability_alerts
       archive_on_destroy          = repo.archive_on_destroy != null ? repo.archive_on_destroy : local.classification_settings[repo.classification].archive_on_destroy
+      default_branch              = repo.default_branch != null ? repo.default_branch : local.classification_settings[repo.classification].default_branch
     }
   }
 }

--- a/terraform/alunduil/locals.tf
+++ b/terraform/alunduil/locals.tf
@@ -27,11 +27,13 @@ locals {
     release-please = {
       allow_auto_merge = true
     }
+  }
 
-    git-flow = {
-      allow_merge_commit = true
-      allow_squash_merge = false
-    }
+  branch_protection_defaults = {
+    required_approving_review_count = 1
+    dismiss_stale_reviews           = true
+    allows_force_pushes             = false
+    allows_deletions                = false
   }
 
   classification_settings = {

--- a/terraform/alunduil/locals.tf
+++ b/terraform/alunduil/locals.tf
@@ -29,13 +29,6 @@ locals {
     }
   }
 
-  branch_protection_defaults = {
-    required_approving_review_count = 1
-    dismiss_stale_reviews           = true
-    allows_force_pushes             = false
-    allows_deletions                = false
-  }
-
   classification_settings = {
     for name, overrides in local.classification_overrides :
     name => merge(local.defaults, overrides)

--- a/terraform/alunduil/repositories.tf
+++ b/terraform/alunduil/repositories.tf
@@ -27,7 +27,6 @@ resource "github_repository" "managed" {
   archive_on_destroy          = local.effective_settings[each.key].archive_on_destroy
 }
 
-# github_repository.default_branch is deprecated; this resource is the supported path.
 resource "github_branch_default" "managed" {
   for_each = var.repositories
 
@@ -46,11 +45,6 @@ resource "github_branch_protection" "managed" {
   repository_id = github_repository.managed[each.key].node_id
   pattern       = github_branch_default.managed[each.key].branch
 
-  allows_deletions    = local.branch_protection_defaults.allows_deletions
-  allows_force_pushes = local.branch_protection_defaults.allows_force_pushes
-
-  required_pull_request_reviews {
-    required_approving_review_count = local.branch_protection_defaults.required_approving_review_count
-    dismiss_stale_reviews           = local.branch_protection_defaults.dismiss_stale_reviews
-  }
+  allows_deletions    = false
+  allows_force_pushes = false
 }

--- a/terraform/alunduil/repositories.tf
+++ b/terraform/alunduil/repositories.tf
@@ -26,3 +26,31 @@ resource "github_repository" "managed" {
   vulnerability_alerts        = local.effective_settings[each.key].vulnerability_alerts
   archive_on_destroy          = local.effective_settings[each.key].archive_on_destroy
 }
+
+# github_repository.default_branch is deprecated; this resource is the supported path.
+resource "github_branch_default" "managed" {
+  for_each = var.repositories
+
+  repository = github_repository.managed[each.key].name
+  branch     = "main"
+}
+
+import {
+  to = github_branch_protection.managed["siren-json.hs"]
+  id = "siren-json.hs:main"
+}
+
+resource "github_branch_protection" "managed" {
+  for_each = var.repositories
+
+  repository_id = github_repository.managed[each.key].node_id
+  pattern       = github_branch_default.managed[each.key].branch
+
+  allows_deletions    = local.branch_protection_defaults.allows_deletions
+  allows_force_pushes = local.branch_protection_defaults.allows_force_pushes
+
+  required_pull_request_reviews {
+    required_approving_review_count = local.branch_protection_defaults.required_approving_review_count
+    dismiss_stale_reviews           = local.branch_protection_defaults.dismiss_stale_reviews
+  }
+}

--- a/terraform/alunduil/repositories.tf
+++ b/terraform/alunduil/repositories.tf
@@ -25,13 +25,22 @@ resource "github_repository" "managed" {
   delete_branch_on_merge      = local.effective_settings[each.key].delete_branch_on_merge
   vulnerability_alerts        = local.effective_settings[each.key].vulnerability_alerts
   archive_on_destroy          = local.effective_settings[each.key].archive_on_destroy
+
+  dynamic "template" {
+    for_each = each.value.template != null ? [each.value.template] : []
+    content {
+      owner                = template.value.owner
+      repository           = template.value.repository
+      include_all_branches = template.value.include_all_branches
+    }
+  }
 }
 
 resource "github_branch_default" "managed" {
   for_each = var.repositories
 
   repository = github_repository.managed[each.key].name
-  branch     = "main"
+  branch     = local.effective_settings[each.key].default_branch
 }
 
 import {

--- a/terraform/alunduil/terraform.tfvars
+++ b/terraform/alunduil/terraform.tfvars
@@ -14,6 +14,7 @@ repositories = {
     description    = "Collection+JSON Tools for Haskell"
     classification = "default"
     topics         = ["haskell-library", "collection-json", "haskell", "hypermedia"]
+    default_branch = "develop"
   }
 
   "grafana" = {
@@ -23,17 +24,20 @@ repositories = {
   "murl" = {
     description    = "Small Toy URL Shortener in Haskell"
     classification = "default"
+    default_branch = "master"
   }
 
   "network-arbitrary" = {
     description    = "Arbitrary Instances for Network Types"
     classification = "default"
+    default_branch = "master"
   }
 
   "network-uri-json" = {
     description    = "FromJSON and ToJSON Instances for Network.URI"
     classification = "default"
     topics         = ["haskell-library", "haskell", "json", "network-uri", "uri"]
+    default_branch = "develop"
   }
 
   "siren-json.hs" = {
@@ -47,12 +51,18 @@ repositories = {
     classification  = "default"
     topics          = ["cli", "generator", "root", "rpg", "tabletop"]
     has_discussions = true
+    default_branch  = "master"
+    template = {
+      owner      = "League-of-Foundry-Developers"
+      repository = "FoundryVTT-Module-Template"
+    }
   }
 
   "zfs-replicate" = {
     description    = "ZFS Replication"
     classification = "default"
     topics         = ["zfs", "replication", "snapshots"]
+    default_branch = "master"
   }
 
 }

--- a/terraform/alunduil/terraform.tfvars
+++ b/terraform/alunduil/terraform.tfvars
@@ -6,33 +6,7 @@ repositories = {
     classification = "default"
   }
 
-  "alunduil-homeassistant" = {
-    description    = "Shared configuration for home assistant (mostly blueprints)."
-    classification = "default"
-  }
-
   "alunduil-infrastructure" = {
-    classification = "default"
-  }
-
-  "alunduil-overlay" = {
-    description    = "Peronal Portage Overlay"
-    classification = "default"
-    topics         = ["deprecated"]
-  }
-
-  "alunduil-sieve" = {
-    description    = "Sieve scripts for reference"
-    classification = "default"
-  }
-
-  "cabal-parser" = {
-    description    = "Cabal Parser Service for Libraries.io bibliothecary"
-    classification = "default"
-  }
-
-  "cfbindings" = {
-    description    = "Cloud Files Linux Style Utilities"
     classification = "default"
   }
 
@@ -42,44 +16,8 @@ repositories = {
     topics         = ["haskell-library", "collection-json", "haskell", "hypermedia"]
   }
 
-  "embodied" = {
-    description    = "Octtree implementation in C++"
-    classification = "default"
-  }
-
-  "gbin" = {
-    description    = "Gentoo Binary Management Service"
-    classification = "default"
-  }
-
   "grafana" = {
     classification = "default"
-  }
-
-  "heapd" = {
-    description    = "Heap as a Service"
-    classification = "default"
-  }
-
-  "hypothesis-requests" = {
-    description    = "Hypothesis strategies for the requests library."
-    classification = "default"
-  }
-
-  "iocage-plugin-acme" = {
-    description    = "FreeNAS Plugin for ACME Certificates"
-    classification = "default"
-  }
-
-  "launch-json" = {
-    description    = "launch-json creates a launch.json from a haskell project for use with haskell-dap in Visual Studio Code"
-    classification = "default"
-  }
-
-  "margarine-chef" = {
-    description    = "Chef cookbook for Margarine"
-    classification = "default"
-    topics         = ["deprecated", "cookbooks", "ruby", "chef", "recipe"]
   }
 
   "murl" = {
@@ -98,68 +36,10 @@ repositories = {
     topics         = ["haskell-library", "haskell", "json", "network-uri", "uri"]
   }
 
-  "pclean" = {
-    description    = "Portage configuration file lint utility."
-    classification = "default"
-    topics         = ["deprecated", "python"]
-  }
-
-  "pl0-compiler" = {
-    description    = "PL/0 compiler"
-    classification = "default"
-  }
-
-  "pmort" = {
-    description    = "Simple local post-mortem analysis logging."
-    classification = "default"
-    topics         = ["deprecated", "python"]
-  }
-
-  "pre-commit-hooks" = {
-    description    = "Custom hooks for pre-commit."
-    classification = "default"
-  }
-
-  "recollect.hs" = {
-    description    = "recollect.hs is a set of remote data collections for example purposes."
-    classification = "default"
-  }
-
-  "singularity" = {
-    description    = "Smaller and more configurable guest agent for Openstack"
-    classification = "default"
-    topics         = ["deprecated", "openstack", "openstack-guest-agent", "python"]
-  }
-
   "siren-json.hs" = {
     description    = "Siren+JSON Tools for Haskell"
     classification = "default"
     topics         = ["haskell-library", "haskell", "siren-json", "hypermedia"]
-  }
-
-  "srforge" = {
-    description    = "Shadowrun Character Forge"
-    classification = "default"
-  }
-
-  "template-graph" = {
-    description    = "Simple graph library based on templating and boost."
-    classification = "default"
-  }
-
-  "template.hs" = {
-    description    = "You can use template.hs to create a new GitHub repository. The repository will have Haskell, VS Code devcontainers, and various GitHub actions ready to use."
-    classification = "default"
-  }
-
-  "torment" = {
-    description    = "A Study in Fixture Based Testing Frameworking"
-    classification = "default"
-  }
-
-  "upkern" = {
-    description    = "Gentoo kernel updater."
-    classification = "default"
   }
 
   "woodland-generators" = {

--- a/terraform/alunduil/variables.tf
+++ b/terraform/alunduil/variables.tf
@@ -34,6 +34,12 @@ variable "repositories" {
     delete_branch_on_merge      = optional(bool)
     vulnerability_alerts        = optional(bool)
     archive_on_destroy          = optional(bool)
+    default_branch              = optional(string)
+    template = optional(object({
+      owner                = string
+      repository           = string
+      include_all_branches = optional(bool, false)
+    }))
   }))
   default = {}
 

--- a/terraform/alunduil/variables.tf
+++ b/terraform/alunduil/variables.tf
@@ -40,8 +40,8 @@ variable "repositories" {
   validation {
     condition = alltrue([
       for name, repo in var.repositories :
-      contains(["default", "release-please", "git-flow"], repo.classification)
+      contains(["default", "release-please"], repo.classification)
     ])
-    error_message = "Classification must be one of: default, release-please, git-flow."
+    error_message = "Classification must be one of: default, release-please."
   }
 }


### PR DESCRIPTION
## Summary

Branch protection and the default branch are now managed by Terraform across every active repo in `var.repositories`: every default branch is protected against force pushes and deletion, and `github_branch_default` records the *current* default branch per repo (`main`, `develop`, or `master`) so renames stay intentional. The unused `git-flow` classification is removed, the 23 repos GitHub had archived outside Terraform are dropped from `terraform.tfvars` so the existing `archive_on_destroy = true` cleanly releases them, and `woodland-generators`'s `League-of-Foundry-Developers/FoundryVTT-Module-Template` link is declared explicitly to keep the diff quiet.

Closes #8.

Verified via `terraform plan`: `1 to import, 19 to add, 1 to change, 23 to destroy`.

## Gotchas

- **The 23 destroys are state-only, not API operations.** Every destroyed `github_repository` has both `archived = true` (refreshed from GitHub) and `archive_on_destroy = true` (from defaults). With both true, the github provider's delete handler returns success without an API call — Terraform forgets the row, GitHub sees nothing.
- **The lone "change" is the audit reconciliation we wanted.** `github_branch_protection["siren-json.hs"]` is imported and then updated in place to drop a stale `required_pull_request_reviews` (1 review, dismiss-stale) and `required_status_checks` (empty, strict=true) carried over from the rename of `develop` → `main`. After apply, the rule matches the new fleet baseline.
- **Import coverage may be incomplete on the other nine active repos.** Only `siren-json.hs:main` has an `import` block. None of the other repos surfaced existing protection rules in this plan, but if any do appear later they need their own `import` block — the v6 provider's GraphQL create can produce a *duplicate* rule rather than overwrite.
- **Protection is just guard rails, no PR/review enforcement.** After your audit feedback, the `required_pull_request_reviews` block is gone — the only thing the rule enforces is `allows_deletions = false` and `allows_force_pushes = false`. PR-only workflow is left to the `no-commit-to-branch` pre-commit hook + habit.
- **State persistence vs. plan refresh.** While verifying I noticed `terraform show -json` reported `siren-json.hs` on `develop`; live GitHub had it on `main`. Plan's refresh updates state in memory only — the persisted state was stale. Worth knowing if you ever script off the JSON state.

## Verification

- Ran `terraform plan` against live GitHub state with the local billing-account `auto.tfvars` you asked me to drop in earlier. Final summary: `1 to import, 19 to add, 1 to change, 23 to destroy` — every line accounted for above.
- Cross-referenced `gh api repos/alunduil/<repo>` against state for each active repo to record actual default branches before recording them in tfvars; six were on `develop`/`master` rather than `main`.
- `terraform fmt` and `terraform validate` pass on every commit; pre-commit suite (terraform_fmt, terraform_validate, REUSE, detect-secrets) clean throughout.