### PR TITLE
Relax yamllint to admit SHA-pinned action references

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -5,6 +5,14 @@
 extends: default
 
 rules:
+  # SHA-pinned GitHub Actions (e.g. `uses: org/repo@<40-char-sha> # vN`)
+  # exceed the 80-char default but cannot be wrapped.
+  line-length:
+    max: 100
+  # Renovate writes a single space before its trailing version comment
+  # (e.g. `... # v4`); accept that style.
+  comments:
+    min-spaces-from-content: 1
   # GitHub Actions uses 'on:' as a top-level key; disable truthy check on keys
   # so workflow files don't have to quote it.
   truthy:


### PR DESCRIPTION
## Summary

yamllint stops failing on SHA-pinned GitHub Actions references, unblocking #29 (and any future Renovate digest-pin PRs). `line-length: max` raised from 80 → 100 (headroom for the 40-char SHA plus typical workflow indentation); `comments: min-spaces-from-content` lowered from 2 → 1 to accept Renovate's `# vN` trailing-version style. The hook still runs with `--strict`, so warnings remain CI-blocking — this just stops Renovate's idiomatic output from tripping defaults.

## Gotchas

100 chars is a chosen ceiling, not a magic one. SHA-pinned `uses:` lines at 8-space indent land at 81-85, so 100 leaves room without going wild. Bump again only if a future deeper-nested action push past it.

## Verification

Locally simulated #29's pinned diff against this config and ran `pre-commit run --all-files` — every hook (yamllint included) passed.