### PR TITLE
Manage DNSSEC on alunduil.com via Terraform

### DIFF
--- a/terraform/alunduil/dns.tf
+++ b/terraform/alunduil/dns.tf
@@ -66,3 +66,9 @@ import {
   to = cloudflare_dns_record.txt_keybase
   id = "${local.cloudflare_zone_id}/f3408d9fed4eebf7fc2a941449a84c62"
 }
+
+# DS values for the Squarespace registrar are exposed via output.alunduil_com_ds.
+resource "cloudflare_zone_dnssec" "alunduil_com" {
+  zone_id = local.cloudflare_zone_id
+  status  = "active"
+}

--- a/terraform/alunduil/outputs.tf
+++ b/terraform/alunduil/outputs.tf
@@ -20,7 +20,6 @@ output "alunduil_com_ds" {
     algorithm   = cloudflare_zone_dnssec.alunduil_com.algorithm
     digest_type = cloudflare_zone_dnssec.alunduil_com.digest_type
     digest      = cloudflare_zone_dnssec.alunduil_com.digest
-    ds          = cloudflare_zone_dnssec.alunduil_com.ds
   }
   description = "DS record fields to publish at the Squarespace registrar for alunduil.com"
 }

--- a/terraform/alunduil/outputs.tf
+++ b/terraform/alunduil/outputs.tf
@@ -12,3 +12,15 @@ output "project_number" {
   description = "alunduil GCP project number"
   sensitive   = false
 }
+
+# DS fields for manual publication at the Squarespace registrar (not TF-managed).
+output "alunduil_com_ds" {
+  value = {
+    key_tag     = cloudflare_zone_dnssec.alunduil_com.key_tag
+    algorithm   = cloudflare_zone_dnssec.alunduil_com.algorithm
+    digest_type = cloudflare_zone_dnssec.alunduil_com.digest_type
+    digest      = cloudflare_zone_dnssec.alunduil_com.digest
+    ds          = cloudflare_zone_dnssec.alunduil_com.ds
+  }
+  description = "DS record fields to publish at the Squarespace registrar for alunduil.com"
+}


### PR DESCRIPTION
## Summary

Closes #40. Adds `cloudflare_zone_dnssec.alunduil_com` (status=active) and surfaces the four DS fields Squarespace's DNSSEC form needs (`key_tag`, `algorithm`, `digest_type`, `digest`) via `output.alunduil_com_ds`. After merge, `terraform apply` flips Cloudflare from `disabled` to `active`; the resulting fields then need to be pasted into Squarespace's DNSSEC settings to complete the chain at the `.com` parent.

Picks the TF-managed option from the issue's TF-vs-manual decision: single resource, drift detection on a security-relevant setting, scope-decoupled from #37 (broader zone management).

## Gotchas

- Squarespace registrar publication is manual — the issue's acceptance criteria (DS at parent, AD flag from validating resolvers) won't be met until that step runs and parent-zone propagation completes (typically <1 hour for `.com`).
- DS values are CF-computed and stable under Universal DNSSEC unless CF rotates keys; if they ever do, the registrar copy goes stale and validating resolvers will go SERVFAIL.

## Verification

- `terraform validate` and `pre-commit` (terraform_fmt, terraform_validate, reuse, detect-secrets) pass.
- Pre-apply state confirmed: `dig DS alunduil.com @a.gtld-servers.net +short` returns empty; `dig alunduil.com @1.1.1.1 +dnssec` returns no AD flag; `dig +dnssec alunduil.com SOA @vick.ns.cloudflare.com` shows RRSIG algo 13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)