### PR TITLE
Bring alunduil.com Cloudflare zone under Terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ and `apply` are run manually after merge to `main`.
 
 - **GCP project** — the `alunduil` project itself (billing, labels,
   foundational APIs)
-- **DNS** — records under `alunduil.com` (the zone is hosted on Cloudflare;
-  Terraform manages records, not the zone itself)
+- **DNS** — the `alunduil.com` Cloudflare zone, a security-relevant subset of
+  zone settings (`ssl`, `min_tls_version`, `always_use_https`,
+  `automatic_https_rewrites`), and all records under it. Other zone settings
+  track Cloudflare's defaults.
 - **GitHub repositories** — settings (visibility, merge rules, discussions, …),
   default branch, branch protection, and (opt-in) Pages for repositories
   owned by `alunduil`, applied via classification (`default`,

--- a/terraform/alunduil/dns.tf
+++ b/terraform/alunduil/dns.tf
@@ -136,6 +136,6 @@ import {
 
 # DS values for the Squarespace registrar are exposed via output.alunduil_com_ds.
 resource "cloudflare_zone_dnssec" "alunduil_com" {
-  zone_id = local.cloudflare_zone_id
+  zone_id = cloudflare_zone.alunduil_com.id
   status  = "active"
 }

--- a/terraform/alunduil/dns.tf
+++ b/terraform/alunduil/dns.tf
@@ -3,10 +3,82 @@
 
 # alunduil.com is hosted on Cloudflare. Authoritative NS:
 #   brenna.ns.cloudflare.com, vick.ns.cloudflare.com
-# The zone itself is not Terraform-managed; only its records are.
+# The zone, a security-relevant subset of zone settings, and all records
+# are Terraform-managed. Settings not declared below track Cloudflare's
+# defaults — add a `cloudflare_zone_setting` resource only when drift
+# detection on a specific one is wanted.
 
 locals {
-  cloudflare_zone_id = "0ee2520bb84646200856ade7817daf2f"
+  cloudflare_account_id = "76626ec3f004e86f1a4d85faca9ac3a2"
+  cloudflare_zone_id    = "0ee2520bb84646200856ade7817daf2f"
+}
+
+# Recreating the zone mints a new Cloudflare NS pair, forcing a registrar
+# update and propagation outage. `prevent_destroy` blocks `terraform
+# destroy` from removing it; deletion has to go through a code change
+# first.
+resource "cloudflare_zone" "alunduil_com" {
+  account = {
+    id = local.cloudflare_account_id
+  }
+  name = "alunduil.com"
+  type = "full"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+import {
+  to = cloudflare_zone.alunduil_com
+  id = local.cloudflare_zone_id
+}
+
+# Zone settings affect proxied records at the edge. All alunduil.com
+# records currently have `proxied = false`, so these are pre-staged for
+# any future proxy flip rather than gating today's traffic.
+resource "cloudflare_zone_setting" "ssl" {
+  zone_id    = local.cloudflare_zone_id
+  setting_id = "ssl"
+  value      = "strict"
+}
+
+resource "cloudflare_zone_setting" "min_tls_version" {
+  zone_id    = local.cloudflare_zone_id
+  setting_id = "min_tls_version"
+  value      = "1.2"
+}
+
+resource "cloudflare_zone_setting" "always_use_https" {
+  zone_id    = local.cloudflare_zone_id
+  setting_id = "always_use_https"
+  value      = "on"
+}
+
+resource "cloudflare_zone_setting" "automatic_https_rewrites" {
+  zone_id    = local.cloudflare_zone_id
+  setting_id = "automatic_https_rewrites"
+  value      = "on"
+}
+
+import {
+  to = cloudflare_zone_setting.ssl
+  id = "${local.cloudflare_zone_id}/ssl"
+}
+
+import {
+  to = cloudflare_zone_setting.min_tls_version
+  id = "${local.cloudflare_zone_id}/min_tls_version"
+}
+
+import {
+  to = cloudflare_zone_setting.always_use_https
+  id = "${local.cloudflare_zone_id}/always_use_https"
+}
+
+import {
+  to = cloudflare_zone_setting.automatic_https_rewrites
+  id = "${local.cloudflare_zone_id}/automatic_https_rewrites"
 }
 
 # blog cuts over from the legacy GCS bucket to GitHub Pages. Proxied stays off

--- a/terraform/alunduil/dns.tf
+++ b/terraform/alunduil/dns.tf
@@ -8,18 +8,13 @@
 # defaults — add a `cloudflare_zone_setting` resource only when drift
 # detection on a specific one is wanted.
 
-locals {
-  cloudflare_account_id = "76626ec3f004e86f1a4d85faca9ac3a2"
-  cloudflare_zone_id    = "0ee2520bb84646200856ade7817daf2f"
-}
-
 # Recreating the zone mints a new Cloudflare NS pair, forcing a registrar
 # update and propagation outage. `prevent_destroy` blocks `terraform
 # destroy` from removing it; deletion has to go through a code change
 # first.
 resource "cloudflare_zone" "alunduil_com" {
   account = {
-    id = local.cloudflare_account_id
+    id = "76626ec3f004e86f1a4d85faca9ac3a2" # pragma: allowlist secret
   }
   name = "alunduil.com"
   type = "full"
@@ -31,61 +26,61 @@ resource "cloudflare_zone" "alunduil_com" {
 
 import {
   to = cloudflare_zone.alunduil_com
-  id = local.cloudflare_zone_id
+  id = "0ee2520bb84646200856ade7817daf2f" # pragma: allowlist secret
 }
 
 # Zone settings affect proxied records at the edge. All alunduil.com
 # records currently have `proxied = false`, so these are pre-staged for
 # any future proxy flip rather than gating today's traffic.
 resource "cloudflare_zone_setting" "ssl" {
-  zone_id    = local.cloudflare_zone_id
+  zone_id    = cloudflare_zone.alunduil_com.id
   setting_id = "ssl"
   value      = "strict"
 }
 
 resource "cloudflare_zone_setting" "min_tls_version" {
-  zone_id    = local.cloudflare_zone_id
+  zone_id    = cloudflare_zone.alunduil_com.id
   setting_id = "min_tls_version"
   value      = "1.2"
 }
 
 resource "cloudflare_zone_setting" "always_use_https" {
-  zone_id    = local.cloudflare_zone_id
+  zone_id    = cloudflare_zone.alunduil_com.id
   setting_id = "always_use_https"
   value      = "on"
 }
 
 resource "cloudflare_zone_setting" "automatic_https_rewrites" {
-  zone_id    = local.cloudflare_zone_id
+  zone_id    = cloudflare_zone.alunduil_com.id
   setting_id = "automatic_https_rewrites"
   value      = "on"
 }
 
 import {
   to = cloudflare_zone_setting.ssl
-  id = "${local.cloudflare_zone_id}/ssl"
+  id = "${cloudflare_zone.alunduil_com.id}/ssl"
 }
 
 import {
   to = cloudflare_zone_setting.min_tls_version
-  id = "${local.cloudflare_zone_id}/min_tls_version"
+  id = "${cloudflare_zone.alunduil_com.id}/min_tls_version"
 }
 
 import {
   to = cloudflare_zone_setting.always_use_https
-  id = "${local.cloudflare_zone_id}/always_use_https"
+  id = "${cloudflare_zone.alunduil_com.id}/always_use_https"
 }
 
 import {
   to = cloudflare_zone_setting.automatic_https_rewrites
-  id = "${local.cloudflare_zone_id}/automatic_https_rewrites"
+  id = "${cloudflare_zone.alunduil_com.id}/automatic_https_rewrites"
 }
 
 # blog cuts over from the legacy GCS bucket to GitHub Pages. Proxied stays off
 # so GitHub can provision a Let's Encrypt cert for the apex CNAME; flip to true
 # once the cert is in place if Cloudflare features are wanted in front.
 resource "cloudflare_dns_record" "blog_cname" {
-  zone_id = local.cloudflare_zone_id
+  zone_id = cloudflare_zone.alunduil_com.id
   name    = "blog.alunduil.com"
   type    = "CNAME"
   content = "alunduil.github.io"
@@ -94,7 +89,7 @@ resource "cloudflare_dns_record" "blog_cname" {
 }
 
 resource "cloudflare_dns_record" "home_cname" {
-  zone_id = local.cloudflare_zone_id
+  zone_id = cloudflare_zone.alunduil_com.id
   name    = "home.alunduil.com"
   type    = "CNAME"
   content = "alunduil.tplinkdns.com"
@@ -103,7 +98,7 @@ resource "cloudflare_dns_record" "home_cname" {
 }
 
 resource "cloudflare_dns_record" "plex_cname" {
-  zone_id = local.cloudflare_zone_id
+  zone_id = cloudflare_zone.alunduil_com.id
   name    = "plex.alunduil.com"
   type    = "CNAME"
   content = "home.alunduil.com"
@@ -112,7 +107,7 @@ resource "cloudflare_dns_record" "plex_cname" {
 }
 
 resource "cloudflare_dns_record" "txt_keybase" {
-  zone_id = local.cloudflare_zone_id
+  zone_id = cloudflare_zone.alunduil_com.id
   name    = "_keybase.alunduil.com"
   type    = "TXT"
   content = "\"keybase-site-verification=KcW7SfZNckcQxOunGDM_ukMY50f3SNovxVDgxAB5pLs\""
@@ -121,20 +116,20 @@ resource "cloudflare_dns_record" "txt_keybase" {
 
 import {
   to = cloudflare_dns_record.blog_cname
-  id = "${local.cloudflare_zone_id}/47c444ffbf44a0cd8d3aa9802e7107c8"
+  id = "${cloudflare_zone.alunduil_com.id}/47c444ffbf44a0cd8d3aa9802e7107c8"
 }
 
 import {
   to = cloudflare_dns_record.home_cname
-  id = "${local.cloudflare_zone_id}/506de57cc5722cdf3db23840786d47cd"
+  id = "${cloudflare_zone.alunduil_com.id}/506de57cc5722cdf3db23840786d47cd"
 }
 
 import {
   to = cloudflare_dns_record.plex_cname
-  id = "${local.cloudflare_zone_id}/e2dbf6462bacfbdd1e2897bfb261d01c"
+  id = "${cloudflare_zone.alunduil_com.id}/e2dbf6462bacfbdd1e2897bfb261d01c"
 }
 
 import {
   to = cloudflare_dns_record.txt_keybase
-  id = "${local.cloudflare_zone_id}/f3408d9fed4eebf7fc2a941449a84c62"
+  id = "${cloudflare_zone.alunduil_com.id}/f3408d9fed4eebf7fc2a941449a84c62"
 }

--- a/terraform/alunduil/project.tf
+++ b/terraform/alunduil/project.tf
@@ -19,8 +19,12 @@ resource "google_project" "env" {
 
   # auto_create_network cannot be changed after project creation.
   # The alunduil project was created before Terraform and has a default network.
+  # prevent_destroy guards against `terraform destroy` taking out the project
+  # (and with it every resource managed in this state); deletion has to go
+  # through a code change first.
   lifecycle {
-    ignore_changes = [auto_create_network]
+    ignore_changes  = [auto_create_network]
+    prevent_destroy = true
   }
 }
 


### PR DESCRIPTION
## Summary

`terraform plan` now catches drift on alunduil.com's edge SSL/TLS posture (mode, version floor, HTTPS enforcement), and `terraform destroy` can no longer remove the zone or the GCP project without a code change first. Closes #37.

## Gotchas

- **Three pinned settings will change on apply** (verified against the live zone). Confirm this is the posture you want before merging — none of the changes affect today's traffic since every record is unproxied, so the security tightening is pre-staged for a future proxy flip rather than gating anything live.

  | Setting | Live | Pinned |
  |---|---|---|
  | `ssl` | `full` | `strict` |
  | `min_tls_version` | `1.0` | `1.2` |
  | `always_use_https` | `off` | `on` |
  | `automatic_https_rewrites` | `on` | `on` (no-op) |

- **`prevent_destroy` on `google_project.env` is scope-creep.** Same risk model as the new zone (destroy is catastrophic, not silently recoverable), so it landed in the same PR. Easy to pull out if you'd rather it be its own change.

## Verification

- Zone metadata (`name`, `type=full`, `account.id`, NS pair) confirmed against `GET /zones/$ZID` — zone import block will succeed without drift.
- All four `cloudflare_zone_setting` live values fetched against `GET /zones/$ZID/settings/<id>` — the table above is the literal delta apply will produce.