### PR TITLE
Enable HTTPS enforcement on blog.alunduil.com Pages via Terraform

### DIFF
--- a/terraform/alunduil/repositories.tf
+++ b/terraform/alunduil/repositories.tf
@@ -41,9 +41,10 @@ resource "github_repository_pages" "managed" {
     if repo.pages != null
   }
 
-  repository = github_repository.managed[each.key].name
-  build_type = each.value.pages.build_type
-  cname      = each.value.pages.cname
+  repository     = github_repository.managed[each.key].name
+  build_type     = each.value.pages.build_type
+  cname          = each.value.pages.cname
+  https_enforced = each.value.pages.https_enforced
 
   # source is only valid for build_type = "legacy"; the GitHub API rejects it
   # for workflow builds.

--- a/terraform/alunduil/terraform.tfvars
+++ b/terraform/alunduil/terraform.tfvars
@@ -16,8 +16,9 @@ repositories = {
     classification = "default"
     topics         = ["blog", "github-pages"]
     pages = {
-      cname      = "blog.alunduil.com"
-      build_type = "workflow"
+      cname          = "blog.alunduil.com"
+      build_type     = "workflow"
+      https_enforced = true
     }
   }
 

--- a/terraform/alunduil/variables.tf
+++ b/terraform/alunduil/variables.tf
@@ -51,8 +51,9 @@ variable "repositories" {
       include_all_branches = optional(bool, false)
     }))
     pages = optional(object({
-      cname      = optional(string)
-      build_type = optional(string, "workflow")
+      cname          = optional(string)
+      build_type     = optional(string, "workflow")
+      https_enforced = optional(bool)
     }))
   }))
   default = {}


### PR DESCRIPTION
## Summary

`blog.alunduil.com` Pages now serves HTTP traffic with a 301 to HTTPS,
managed by Terraform — no more manual toggle in the Pages UI.

## Gotchas

- **Issue #35's premise was stale.** The motivation said "the GitHub
  provider doesn't expose `enforce_https` cleanly enough to manage in
  Terraform." That changed under us:
  [terraform-provider-github#3168](https://github.com/integrations/terraform-provider-github/pull/3168)
  merged 2026-04-22, shipped in v6.12.0 the next day, and the lockfile
  is already on v6.12.1 (commit `2bb1846`). So instead of the manual
  UI flip, the field flows through the `var.repositories` `pages`
  schema (`https_enforced = optional(bool)`), defaulting to `null` so
  existing repos see no plan diff.
- **Provider quirk to note:** `https_enforced` only applies when
  `cname` is set. `blog.alunduil.com` already has one, so this is a
  no-op constraint here, but worth knowing if a future Pages site goes
  in without a custom domain.

## Verification

- `terraform validate` passes; `terraform fmt -check` clean.
- `terraform plan` against the live state produces a single
  in-place update on `github_repository_pages.managed["blog.alunduil.com"]`,
  flipping `https_enforced = false -> true`. No drift on anything else.
  ```
  Plan: 0 to add, 1 to change, 0 to destroy.
  ```
- HTTP-redirect verification (the issue's third acceptance criterion)
  has to wait until apply lands on main; current `curl -sI
  http://blog.alunduil.com` returns 404 directly because Pages doesn't
  redirect to HTTPS until the setting flips.

Closes #35.