### PR TITLE
Add repo-local CLAUDE.md for AI sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+<!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<!--
+Maintainer notes (HTML comments are stripped from Claude's context):
+- AI-targeted, loaded every session. Optimise for tokens; keep
+  under ~50 lines.
+- Add an entry only when Claude has made the same mistake twice
+  or a non-obvious convention bit a session.
+- Prefer pointers (README §..., file:line) over copies of content
+  that already lives elsewhere.
+- Human-facing context lives in [README](README.md); no
+  CONTRIBUTING.md (single maintainer; outside contributions are
+  not solicited).
+-->
+
+# alunduil-infrastructure — Claude guide
+
+## Contribution flow
+
+- **Open draft PRs only.** Don't push to `main`; don't merge your
+  own PRs. alunduil reviews and merges.
+- **Don't run `terraform apply`.** alunduil runs it on `main`
+  post-merge from the local shell. `terraform plan` output in the
+  PR body is welcome.
+- **Follow-ups land in a new session and a new PR.** A merged PR
+  is done — don't keep iterating on it for adjacent work.
+
+## Layout
+
+- Terraform: `terraform/alunduil/`. One environment (personal infra;
+  no dev/prod split).
+- Manual steps that stay outside Terraform: README §"Stays manual".
+  Check there before assuming a thing should live in `.tf`.
+
+## Gotchas
+
+- `alunduil.com` DNS is on Cloudflare, not Cloud DNS. Run
+  `dig NS alunduil.com` before treating a TF DNS resource as
+  authoritative.
+- Pre-commit hooks (REUSE, terraform_fmt/validate, markdownlint,
+  yamllint, detect-secrets) must pass. New files need SPDX
+  headers — REUSE flags missing ones.


### PR DESCRIPTION
## Summary

New `CLAUDE.md` at repo root captures the contribution flow Claude
sessions kept re-deriving: open draft PRs only, alunduil reviews
and merges, alunduil runs `terraform apply` on main post-merge,
follow-ups land in a fresh session/PR. Repo-local CLAUDE.md
outranks user auto-memory and survives memory wipes, so this is
the durable home for the rule.

Also covers two repo-specific bits: the Terraform layout and one
environment, plus the Cloudflare-not-Cloud-DNS gotcha that has
caught past sessions.

Closes #46.

## Research used to shape the file

Per the issue's acceptance criterion, recording what informed the
shape:

- **[Anthropic — How Claude remembers your project](https://code.claude.com/docs/en/memory)**:
  target <200 lines; bloat reduces adherence; specific over
  general; block-level HTML comments are stripped from Claude's
  context (used for the maintainer note about keeping the file
  short).
- **[Anthropic — Best practices for Claude Code](https://code.claude.com/docs/en/best-practices)**:
  ✅ include bash commands Claude can't guess, repo etiquette,
  arch decisions specific to the project, env quirks, common
  gotchas; ❌ exclude things Claude can derive from code, standard
  conventions, frequently-changing info, file-by-file descriptions.
- **[HumanLayer — Writing a good CLAUDE.md](https://www.humanlayer.dev/blog/writing-a-good-claude-md)**:
  root file <60 lines (theirs); WHAT/WHY/HOW dimensions; prefer
  pointers over copies; don't duplicate linters.

The file lands at ~32 visible lines (HTML comments stripped),
under both targets.

### CLAUDE.md vs CONTRIBUTING.md split

CLAUDE.md gets the AI-targeted rules (don't merge, don't apply,
follow-ups in new sessions). Human-facing context already lives in
[README](README.md) §"Running an apply" and §"Stays manual";
CLAUDE.md points there rather than duplicating.

**No CONTRIBUTING.md added.** README §"Support and contributions"
already states outside contributors aren't actively solicited. The
`contributing` skill's nayafia template assumes multiple
contributors; for a single-maintainer personal-infra repo it would
be ceremonial.

## Gotchas

Focus review on the **Contribution flow** section — that's the
load-bearing content from #46. Trim or rephrase if anything reads
ambiguously to a future fresh-context session.

## Verification

- `pre-commit run --files CLAUDE.md` — REUSE, markdownlint,
  detect-secrets, line-ending checks all pass.