### PR TITLE
Add tooling inventory and scope discipline to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 <!--
 Maintainer notes (HTML comments are stripped from Claude's context):
 - AI-targeted, loaded every session. Optimise for tokens; keep
-  under ~50 lines.
+  under ~75 lines.
 - Add an entry only when Claude has made the same mistake twice
   or a non-obvious convention bit a session.
 - Prefer pointers (README §..., file:line) over copies of content
@@ -25,6 +25,32 @@ Maintainer notes (HTML comments are stripped from Claude's context):
   PR body is welcome.
 - **Follow-ups land in a new session and a new PR.** A merged PR
   is done — don't keep iterating on it for adjacent work.
+
+## Tooling inventory
+
+Before scripting from first principles or hitting APIs by hand,
+check what's already in place:
+
+- Helper scripts: `scripts/`. New shell helpers go here, not the
+  repo root. State-bucket bootstrap: `bootstrap-terraform-state.sh`.
+- Renovate (`renovate.json`) handles dependency PRs; extend the
+  config rather than pinning by hand.
+- Credentials: README §"Running an apply" names the env vars
+  needed; §"Stays manual" covers the Cloudflare scopes and the
+  `TF_VAR_cloudflare_api_token` workaround. Don't enumerate token
+  paths in committed files.
+
+## Scope discipline
+
+`terraform apply` runs out-of-band post-merge, so an unrelated edit
+in a scoped PR ships infra the reviewer didn't ask for.
+
+- Confirm scope doesn't overlap sibling or linked issues before
+  opening the PR; ask if uncertain.
+- An issue blocked by unshipped prerequisites: propose deferral
+  with a `blocked-by` edge rather than write premature code.
+- Revert incidental edits (formatting, drive-by tweaks) before
+  requesting review.
 
 ## Layout
 


### PR DESCRIPTION
## Summary

CLAUDE.md gains two repo-specific sections: a Tooling inventory
(scripts/, Renovate, where credential setup is documented) so the
first move on an API task is discovery instead of writing
`curl`-based scaffolding, and a Scope discipline note so an
out-of-band `terraform apply` doesn't ship unrelated edits a
scoped PR slipped in.

## Gotchas

The Credentials bullet points at README §"Running an apply" and
§"Stays manual" instead of enumerating token paths — pointing at
where secrets live in committed docs is prompt-injection bait
(prior feedback in this repo, after `secrets.auto.tfvars` was
called out in earlier README work).

Bumped the maintainer line-cap from ~50 to ~75 to admit the new
sections; file is now 69 lines.

## Verification

- `pre-commit run --files CLAUDE.md` — all hooks pass (markdownlint,
  REUSE, detect-secrets, end-of-file-fixer, etc.).

Closes #60