### PR TITLE
Drop default_branch override on network-uri-json

### DIFF
--- a/terraform/alunduil/repositories.tf
+++ b/terraform/alunduil/repositories.tf
@@ -51,11 +51,10 @@ module "network_arbitrary" {
 }
 
 module "network_uri_json" {
-  source         = "../modules/github_repository"
-  name           = "network-uri-json"
-  description    = "FromJSON and ToJSON Instances for Network.URI"
-  topics         = ["haskell-library", "haskell", "json", "network-uri", "uri"]
-  default_branch = "develop"
+  source      = "../modules/github_repository"
+  name        = "network-uri-json"
+  description = "FromJSON and ToJSON Instances for Network.URI"
+  topics      = ["haskell-library", "haskell", "json", "network-uri", "uri"]
 }
 
 module "siren_json_hs" {


### PR DESCRIPTION
## Summary

Terraform stops asking for `develop` as the default branch on `network-uri-json`, which matches the upstream rename (alunduil/network-uri-json#70). The module's default of `main` takes over.

## Gotchas

The `main` branch on GitHub still carries protection inherited from the old `master` config — `required_pull_request_reviews` and `required_status_checks` — that the `github_branch_protection` resource in `modules/github_repository/main.tf` doesn't declare. Applying this will strip those rules. That's the accepted outcome here (per the issue body); reintroducing them is deferred to a later pass when network-uri-json's CI lands under its V2/V6 milestones.

Closes #58.