### PR TITLE
Harden Renovate config with bake period and validator hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,3 +61,10 @@ repos:
     rev: v1.5.0
     hooks:
       - id: detect-secrets
+
+  # Renovate config validation
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 43.150.0
+    hooks:
+      - id: renovate-config-validator
+        args: [--strict, --no-global]

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This is personal infrastructure maintained for the author's own use. Issues
 and pull requests from outside collaborators are not actively solicited and
 may not be triaged.
 
-## Licence
+## License
 
 MIT — see [LICENSES/MIT.txt](LICENSES/MIT.txt) or the `SPDX-License-Identifier`
 headers on each file.

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,12 @@
   "extends": ["config:best-practices"],
   "baseBranchPatterns": ["main"],
   "reviewers": ["alunduil"],
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0 days"
+  },
+  "osvVulnerabilityAlerts": true,
   "pre-commit": {
     "enabled": true
   },


### PR DESCRIPTION
## Summary

Renovate now waits 3 days after a release before opening a PR, so a
malicious version yanked within that window never reaches the
dashboard; CVE alerts keep flowing without delay via the 0-day
`vulnerabilityAlerts` carve-out, and `osvVulnerabilityAlerts` widens
the alert source beyond GitHub's advisory database. A new
`renovate-config-validator` pre-commit hook catches schema typos and
deprecated field renames at commit time rather than as Repository
Problems on the next run.

Piggybacks a one-character README fix: the "Licence" heading now
matches the "License" badge alt-text six lines above.

## Gotchas

`internalChecksFilter: "strict"` is load-bearing — without it
Renovate opens PRs immediately and marks them "pending", defeating
the bake period. Spot-check the dashboard once the next batch is due
to confirm bakes are actually delaying PRs rather than silently
opening them labelled pending.

## Verification

`pre-commit run --all-files` passes locally, including the new
`renovate-config-validator` hook against the updated `renovate.json`.