### PR TITLE
Add justfile for bootstrap and alunduil entrypoints

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
-    # Runs every pre-commit hook on all files. The terraform hooks need the
-    # terraform binary (installed below); the rest are Python-based and
-    # handled by pre-commit/action.
+    # Runs every pre-commit hook on all files. Terraform and just are
+    # installed below for hooks that shell out to those binaries; the
+    # rest are Python-based and handled by pre-commit/action.
 
     steps:
       - name: Checkout repository
@@ -31,6 +31,9 @@ jobs:
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_version: '1.15.4'
+
+      - name: Set up just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
 
       - name: Run pre-commit hooks
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,3 +68,13 @@ repos:
     hooks:
       - id: renovate-config-validator
         args: [--strict, --no-global]
+
+  # justfile format and parse check
+  - repo: local
+    hooks:
+      - id: just-fmt-check
+        name: just --fmt --check
+        entry: just --fmt --check
+        language: system
+        files: ^justfile$
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -14,9 +14,15 @@ Personal infrastructure as code, managed with Terraform.
 
 ## Getting started
 
-How-tos for the operator-facing procedures:
+The two operator entrypoints:
 
-- [docs/how-to/bootstrap.md](docs/how-to/bootstrap.md)
+- `just bootstrap` — first-time setup or credential rotation. See
+  [docs/how-to/bootstrap.md](docs/how-to/bootstrap.md).
+- `just alunduil` — local `terraform apply` against the alunduil
+  environment, run after merging to `main`.
+
+Supporting how-tos:
+
 - [docs/how-to/create-master-cloudflare-token.md](docs/how-to/create-master-cloudflare-token.md)
 - [docs/how-to/create-github-app.md](docs/how-to/create-github-app.md)
 

--- a/docs/how-to/bootstrap.md
+++ b/docs/how-to/bootstrap.md
@@ -24,10 +24,3 @@ export CLOUDFLARE_API_TOKEN=...
 
 just bootstrap
 ```
-
-`just bootstrap` runs `scripts/bootstrap-terraform-state.sh`, then
-`terraform init && terraform apply` against `terraform/bootstrap/`,
-then `scripts/configure-github-secrets.sh` — all idempotent, safe to
-re-run after a partial failure. The secrets script prompts for the
-GitHub App ID and `.pem` path when those aren't already in env vars
-(`GH_APP_ID`, `GH_APP_PRIVATE_KEY_FILE`) or set as repo secrets.

--- a/docs/how-to/bootstrap.md
+++ b/docs/how-to/bootstrap.md
@@ -10,34 +10,24 @@ credentials.
 
 ## Prerequisites
 
-- The state bucket `alunduil-tfstate` exists — created out-of-band by
-  [bootstrap-terraform-state.sh](../../scripts/bootstrap-terraform-state.sh).
 - A master Cloudflare API token — see
   [create-master-cloudflare-token.md](create-master-cloudflare-token.md).
 - A GitHub App created and installed — see
   [create-github-app.md](create-github-app.md).
 
-## Apply
-
-From `terraform/bootstrap/`:
+## Run
 
 ```sh
 gcloud auth application-default login
 export TF_VAR_billing_account_id=XXXXXX-XXXXXX-XXXXXX
 export CLOUDFLARE_API_TOKEN=...
 
-terraform init
-terraform plan
-terraform apply
+just bootstrap
 ```
 
-## Configure GitHub Actions secrets
-
-```sh
-scripts/configure-github-secrets.sh
-```
-
-Prompts for the GitHub App ID and a path to the `.pem` private key
-when those aren't already in env vars (`GH_APP_ID`,
-`GH_APP_PRIVATE_KEY_FILE`) or set in repo secrets. Re-running is a
-no-op.
+`just bootstrap` runs `scripts/bootstrap-terraform-state.sh`, then
+`terraform init && terraform apply` against `terraform/bootstrap/`,
+then `scripts/configure-github-secrets.sh` — all idempotent, safe to
+re-run after a partial failure. The secrets script prompts for the
+GitHub App ID and `.pem` path when those aren't already in env vars
+(`GH_APP_ID`, `GH_APP_PRIVATE_KEY_FILE`) or set as repo secrets.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# All three steps are idempotent; safe to re-run after partial failure.
+[doc("Manual surface: state bucket → bootstrap layer → CI secrets.")]
+bootstrap:
+    scripts/bootstrap-terraform-state.sh
+    terraform -chdir=terraform/bootstrap init
+    terraform -chdir=terraform/bootstrap apply
+    scripts/configure-github-secrets.sh
+
+# Requires CLOUDFLARE_API_TOKEN and TF_VAR_cloudflare_api_token in env.
+[doc("Local post-merge apply for the alunduil environment.")]
+alunduil:
+    terraform -chdir=terraform/alunduil init
+    terraform -chdir=terraform/alunduil apply

--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ bootstrap:
     terraform -chdir=terraform/bootstrap apply
     scripts/configure-github-secrets.sh
 
-# Requires CLOUDFLARE_API_TOKEN and TF_VAR_cloudflare_api_token in env.
+# Requires TF_VAR_cloudflare_api_token in env (or terraform will prompt).
 [doc("Local post-merge apply for the alunduil environment.")]
 alunduil:
     terraform -chdir=terraform/alunduil init


### PR DESCRIPTION
## Summary

Two named recipes wrap the existing scripts so the manual and local-apply rituals each have one discoverable entrypoint instead of an ordered list of commands to remember:

- `just bootstrap` — `scripts/bootstrap-terraform-state.sh` → `terraform -chdir=terraform/bootstrap init && apply` → `scripts/configure-github-secrets.sh`, all idempotent and resumable.
- `just alunduil` — `terraform -chdir=terraform/alunduil init && apply` for the post-merge ritual.

`just --list` summaries come from the `[doc(...)]` attribute so the inline comments stay free to flag implementation detail (idempotence, expected env vars).

The README and `docs/how-to/bootstrap.md` now point at the new entrypoints, and `.pre-commit-config.yaml` gains a local `just --fmt --check` hook (with a matching `setup-just` step in the pre-commit CI workflow).

## Gotchas

- The `alunduil` recipe assumes `TF_VAR_cloudflare_api_token` is in env; if missing, terraform prompts for it (the variable is `sensitive`, so the prompt is masked). The recipe deliberately doesn't source any secret-path file — your shell rcfile / direnv handles that.
- `just` itself isn't pinned in the repo; local runs rely on host install. CI installs it via `extractions/setup-just@<sha> # v4` so the new format hook can execute there.

## Verification

- Ran `just --list`; both recipes render with their `[doc(...)]` summaries.
- Ran `pre-commit run --all-files`; all 17 hooks pass, including the new `just --fmt --check`.
- Did not run `just bootstrap` or `just alunduil` — both touch live state and apply is yours to run.