### PR TITLE
Move Cloudflare deployer tokens into GCP Secret Manager

### DIFF
--- a/scripts/configure-github-secrets.sh
+++ b/scripts/configure-github-secrets.sh
@@ -2,13 +2,16 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 #
-# Idempotently configures the eight GitHub Actions secrets that the Terraform
+# Idempotently configures the six GitHub Actions secrets that the Terraform
 # CI workflows consume.
 #
-# Six values come from `terraform output` against terraform/bootstrap/:
+# Four values come from `terraform output` against terraform/bootstrap/:
 #   - GCP_RO_WORKLOAD_IDENTITY_PROVIDER, GCP_RO_SERVICE_ACCOUNT_EMAIL
 #   - GCP_RW_WORKLOAD_IDENTITY_PROVIDER, GCP_RW_SERVICE_ACCOUNT_EMAIL
-#   - TF_VAR_CLOUDFLARE_API_TOKEN_RO, TF_VAR_CLOUDFLARE_API_TOKEN_RW
+#
+# The Cloudflare deployer tokens are not GitHub Actions secrets: the
+# workflows authenticate to GCP via WIF and then fetch the token from
+# Secret Manager at apply time. The token value never lives in Actions.
 #
 # Two come from a GitHub App that the workflow exchanges for short-lived
 # installation tokens via OIDC:
@@ -33,8 +36,6 @@ gh auth status >/dev/null 2>&1 || { echo "error: gh is not authenticated; run 'g
 WIF_PROVIDER="$(terraform -chdir="${BOOTSTRAP_DIR}" output -raw workload_identity_provider)"
 RO_SA_EMAIL="$(terraform -chdir="${BOOTSTRAP_DIR}" output -raw github_deployer_ro_email)"
 RW_SA_EMAIL="$(terraform -chdir="${BOOTSTRAP_DIR}" output -raw github_deployer_rw_email)"
-CF_TOKEN_RO="$(terraform -chdir="${BOOTSTRAP_DIR}" output -raw cloudflare_api_token_deployer_ro)"
-CF_TOKEN_RW="$(terraform -chdir="${BOOTSTRAP_DIR}" output -raw cloudflare_api_token_deployer_rw)"
 
 existing_secrets="$(gh secret list --json name --jq '.[].name')"
 has_secret() { grep -Fxq "$1" <<<"${existing_secrets}"; }
@@ -102,8 +103,6 @@ declare -A SECRETS=(
   [GCP_RO_SERVICE_ACCOUNT_EMAIL]="${RO_SA_EMAIL}"
   [GCP_RW_WORKLOAD_IDENTITY_PROVIDER]="${WIF_PROVIDER}"
   [GCP_RW_SERVICE_ACCOUNT_EMAIL]="${RW_SA_EMAIL}"
-  [TF_VAR_CLOUDFLARE_API_TOKEN_RO]="${CF_TOKEN_RO}"
-  [TF_VAR_CLOUDFLARE_API_TOKEN_RW]="${CF_TOKEN_RW}"
   [GH_APP_ID]="${GH_APP_ID_VALUE}"
   [GH_APP_PRIVATE_KEY]="${GH_APP_PRIVATE_KEY_VALUE}"
 )
@@ -136,5 +135,5 @@ if [[ -n "${missing}" ]]; then
 fi
 
 if [[ -z "${unexpected}" && -z "${missing}" ]]; then
-  echo "All eight secrets present, no drift."
+  echo "All six secrets present, no drift."
 fi

--- a/terraform/alunduil/project.tf
+++ b/terraform/alunduil/project.tf
@@ -1,38 +1,6 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 
-removed {
-  from = google_project.env
-
-  lifecycle {
-    destroy = false
-  }
-}
-
-removed {
-  from = google_project_service.iam
-
-  lifecycle {
-    destroy = false
-  }
-}
-
-removed {
-  from = google_project_service.cloudresourcemanager
-
-  lifecycle {
-    destroy = false
-  }
-}
-
-removed {
-  from = google_project_service.serviceusage
-
-  lifecycle {
-    destroy = false
-  }
-}
-
 resource "google_project_service" "storage_api" {
   project = data.terraform_remote_state.bootstrap.outputs.project_id
   service = "storage-api.googleapis.com"

--- a/terraform/bootstrap/cloudflare_tokens.tf
+++ b/terraform/bootstrap/cloudflare_tokens.tf
@@ -59,3 +59,55 @@ resource "cloudflare_api_token" "deployer_rw" {
     resources = local.alunduil_com_zone_resource
   }]
 }
+
+# The deployer SAs hold `objectViewer`/`objectAdmin` on the shared
+# `alunduil-tfstate` bucket, which means anything that lands a plan job
+# could `gsutil cat` bootstrap state. Holding token values directly in
+# state — even with `sensitive = true` — leaks them at that layer. Per-
+# secret accessor IAM moves the authorization check off the bucket and
+# onto each secret: RO SA reaches only the RO token, RW SA only the RW.
+resource "google_secret_manager_secret" "cloudflare_api_token_deployer_ro" {
+  project   = google_project.env.project_id
+  secret_id = "cloudflare-api-token-deployer-ro"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret_version" "cloudflare_api_token_deployer_ro" {
+  secret      = google_secret_manager_secret.cloudflare_api_token_deployer_ro.id
+  secret_data = cloudflare_api_token.deployer_ro.value
+}
+
+resource "google_secret_manager_secret_iam_member" "cloudflare_api_token_deployer_ro_accessor" {
+  project   = google_secret_manager_secret.cloudflare_api_token_deployer_ro.project
+  secret_id = google_secret_manager_secret.cloudflare_api_token_deployer_ro.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.github_deployer_ro.email}"
+}
+
+resource "google_secret_manager_secret" "cloudflare_api_token_deployer_rw" {
+  project   = google_project.env.project_id
+  secret_id = "cloudflare-api-token-deployer-rw"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret_version" "cloudflare_api_token_deployer_rw" {
+  secret      = google_secret_manager_secret.cloudflare_api_token_deployer_rw.id
+  secret_data = cloudflare_api_token.deployer_rw.value
+}
+
+resource "google_secret_manager_secret_iam_member" "cloudflare_api_token_deployer_rw_accessor" {
+  project   = google_secret_manager_secret.cloudflare_api_token_deployer_rw.project
+  secret_id = google_secret_manager_secret.cloudflare_api_token_deployer_rw.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.github_deployer_rw.email}"
+}

--- a/terraform/bootstrap/outputs.tf
+++ b/terraform/bootstrap/outputs.tf
@@ -25,14 +25,14 @@ output "github_deployer_rw_email" {
   sensitive   = false
 }
 
-output "cloudflare_api_token_deployer_ro" {
-  value       = cloudflare_api_token.deployer_ro.value
-  description = "Cloudflare API token value for the RO deployer (Zone Read + DNS Read + Zone Settings Read on alunduil.com)"
-  sensitive   = true
+output "cloudflare_api_token_deployer_ro_secret" {
+  value       = google_secret_manager_secret.cloudflare_api_token_deployer_ro.secret_id
+  description = "Secret Manager short name holding the RO deployer's Cloudflare API token; fetched at plan time via `gcloud secrets versions access`"
+  sensitive   = false
 }
 
-output "cloudflare_api_token_deployer_rw" {
-  value       = cloudflare_api_token.deployer_rw.value
-  description = "Cloudflare API token value for the RW deployer (Zone Read + DNS Write + Zone Settings Write on alunduil.com)"
-  sensitive   = true
+output "cloudflare_api_token_deployer_rw_secret" {
+  value       = google_secret_manager_secret.cloudflare_api_token_deployer_rw.secret_id
+  description = "Secret Manager short name holding the RW deployer's Cloudflare API token; fetched at apply time via `gcloud secrets versions access`"
+  sensitive   = false
 }

--- a/terraform/bootstrap/project.tf
+++ b/terraform/bootstrap/project.tf
@@ -20,21 +20,11 @@ resource "google_project" "env" {
   }
 }
 
-import {
-  to = google_project.env
-  id = "alunduil"
-}
-
 resource "google_project_service" "iam" {
   project = google_project.env.project_id
   service = "iam.googleapis.com"
 
   disable_on_destroy = false
-}
-
-import {
-  to = google_project_service.iam
-  id = "alunduil/iam.googleapis.com"
 }
 
 resource "google_project_service" "cloudresourcemanager" {
@@ -46,11 +36,6 @@ resource "google_project_service" "cloudresourcemanager" {
   depends_on = [google_project_service.iam]
 }
 
-import {
-  to = google_project_service.cloudresourcemanager
-  id = "alunduil/cloudresourcemanager.googleapis.com"
-}
-
 resource "google_project_service" "serviceusage" {
   project = google_project.env.project_id
   service = "serviceusage.googleapis.com"
@@ -58,9 +43,4 @@ resource "google_project_service" "serviceusage" {
   disable_on_destroy = false
 
   depends_on = [google_project_service.iam]
-}
-
-import {
-  to = google_project_service.serviceusage
-  id = "alunduil/serviceusage.googleapis.com"
 }

--- a/terraform/bootstrap/project.tf
+++ b/terraform/bootstrap/project.tf
@@ -44,3 +44,12 @@ resource "google_project_service" "serviceusage" {
 
   depends_on = [google_project_service.iam]
 }
+
+resource "google_project_service" "secretmanager" {
+  project = google_project.env.project_id
+  service = "secretmanager.googleapis.com"
+
+  disable_on_destroy = false
+
+  depends_on = [google_project_service.iam]
+}


### PR DESCRIPTION
## Summary

Bootstrap no longer outputs Cloudflare deployer token values; the values live in GCP Secret Manager with per-secret `secretAccessor` IAM (RO secret ↔ RO deployer SA, RW ↔ RW), and #63's workflows will `gcloud secrets versions access` them at apply time so the value never touches a GitHub Actions secret. Closes the Secret-Manager-API half of the bucket-share path where a compromised plan workflow could lift the RW Cloudflare token.

Also drops the post-migration `removed{}`/`import{}` scaffolding from PR #72 (no-op since that apply; piggyback called out in #77).

## Gotchas

- **The bucket-share path isn't fully closed by this PR.** `cloudflare_api_token.deployer_*.value` still lives in bootstrap state in plaintext, and the new `secret_data` adds a second copy in the same state. RO SA's bucket-wide `objectViewer` means the plan workflow can still `gsutil cat` bootstrap state and read the RW token from there. The structural fix is splitting the bucket — tracked in #80. Per-secret SM IAM closes the SM-API path only.
- **Other follow-ups from the same review.** #81 narrows the WIF RW binding to `refs/heads/main`. #82 tightens the GitHub App install scope and prunes `Administration: RW`. #83 enables GCP Data Access audit logs so reads against the bucket and SM are observable. #84 (C4 model) and #85 (formal threat model, blocked-by #84) frame future work.
- **State history.** Bootstrap state versioning holds the pre-change token values from PR #72; #80 needs to purge those noncurrent versions as part of the bucket split. CF token rotation after that split is the clean recovery path.
- **`cloudflare_api_token` resources are unchanged** in this PR (only outputs change). First `terraform apply` should show two new SM secrets + versions + IAM bindings and the output rename — no changes to the CF tokens themselves.
- **Workflow consumer doesn't exist yet.** The last bullet of #77's acceptance criteria lands with #63.

## Verification

- `terraform validate` passes against both `terraform/bootstrap/` and `terraform/alunduil/`.
- `pre-commit run` passes on the touched files (fmt, validate, REUSE, detect-secrets); CI's "All hooks" job is green on the PR.
- `bash -n scripts/configure-github-secrets.sh` parses; `SECRETS` map drops to six entries and the drift-check summary line updates to match.
- `terraform plan` / `apply` against bootstrap deferred to alunduil post-merge — last acceptance criterion ("`terraform plan` against bootstrap is a no-op after migration") needs operator confirmation.