### PR TITLE
Enable Data Access audit logs on storage and secretmanager

### DIFF
--- a/terraform/bootstrap/project.tf
+++ b/terraform/bootstrap/project.tf
@@ -53,3 +53,29 @@ resource "google_project_service" "secretmanager" {
 
   depends_on = [google_project_service.iam]
 }
+
+# Data Access logs are opt-in per service. Without these, a compromised
+# plan job could `gsutil cat` state or `gcloud secrets versions access`
+# a deployer token and leave no trace beyond the STS impersonation row
+# in Admin Activity.
+resource "google_project_iam_audit_config" "storage" {
+  project = google_project.env.project_id
+  service = "storage.googleapis.com"
+
+  audit_log_config {
+    log_type = "DATA_READ"
+  }
+
+  audit_log_config {
+    log_type = "DATA_WRITE"
+  }
+}
+
+resource "google_project_iam_audit_config" "secretmanager" {
+  project = google_project.env.project_id
+  service = "secretmanager.googleapis.com"
+
+  audit_log_config {
+    log_type = "DATA_READ"
+  }
+}


### PR DESCRIPTION
## Summary

Cloud Logging now records reads of the Terraform state bucket and the Cloudflare deployer token secrets — `storage.objects.get` and `google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion` will leave a row in Cloud Audit Logs.

Storage gets `DATA_READ` + `DATA_WRITE`; Secret Manager gets `DATA_READ` (writes are already covered by Admin Activity via Secret Manager's resource-create path). Both declared as `google_project_iam_audit_config` in `terraform/bootstrap/project.tf` since they're project-wide.

## Gotchas

- Punted on `iam.googleapis.com` / `sts.googleapis.com` Data Access logs — the issue flagged them as possibly out of scope; can land in a follow-up if you want the non-impersonation access trail on the SAs themselves.
- Data Access logs are free under a per-project quota that's well above homelab traffic; no cost surprise expected.

## Verification

- `terraform validate` passes.
- Runtime acceptance criteria (a bucket read / secret access produces a Cloud Logging row) is deferred to post-apply — I don't run apply.

Closes #83