### PR TITLE
Gate RW deployer impersonation on refs/heads/main

### DIFF
--- a/terraform/bootstrap/github_oidc.tf
+++ b/terraform/bootstrap/github_oidc.tf
@@ -43,6 +43,7 @@ resource "google_iam_workload_identity_pool_provider" "github" {
     "attribute.repository"       = "assertion.repository"
     "attribute.repository_owner" = "assertion.repository_owner"
     "attribute.environment"      = "assertion.environment"
+    "attribute.ref"              = "assertion.ref"
   }
 
   attribute_condition = "assertion.repository == 'alunduil/alunduil-infrastructure'"
@@ -53,5 +54,6 @@ resource "google_iam_workload_identity_pool_provider" "github" {
 }
 
 locals {
-  wif_principal = "principalSet://iam.googleapis.com/projects/${google_project.env.number}/locations/global/workloadIdentityPools/github/attribute.repository/alunduil/alunduil-infrastructure"
+  wif_principal      = "principalSet://iam.googleapis.com/projects/${google_project.env.number}/locations/global/workloadIdentityPools/github/attribute.repository/alunduil/alunduil-infrastructure"
+  wif_principal_main = "principalSet://iam.googleapis.com/projects/${google_project.env.number}/locations/global/workloadIdentityPools/github/attribute.ref/refs/heads/main"
 }

--- a/terraform/bootstrap/service_account_github_deployer_rw.tf
+++ b/terraform/bootstrap/service_account_github_deployer_rw.tf
@@ -51,7 +51,7 @@ resource "google_storage_bucket_iam_member" "github_deployer_rw_state_bucket_rea
 resource "google_service_account_iam_member" "github_deployer_rw_workload_identity_user" {
   service_account_id = google_service_account.github_deployer_rw.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = local.wif_principal
+  member             = local.wif_principal_main
 
   depends_on = [google_iam_workload_identity_pool_provider.github]
 }
@@ -59,7 +59,7 @@ resource "google_service_account_iam_member" "github_deployer_rw_workload_identi
 resource "google_service_account_iam_member" "github_deployer_rw_token_creator" {
   service_account_id = google_service_account.github_deployer_rw.name
   role               = "roles/iam.serviceAccountTokenCreator"
-  member             = local.wif_principal
+  member             = local.wif_principal_main
 
   depends_on = [google_iam_workload_identity_pool_provider.github]
 }


### PR DESCRIPTION
## Summary

The RW deployer SA can now only be impersonated by a GitHub Actions
run on `refs/heads/main`. Branch pushes, branch `workflow_dispatch`,
and PR jobs no longer reach `terraform apply`-grade credentials.

`attribute.ref` joins the WIF attribute mapping; the new
`local.wif_principal_main` (a `principalSet` keyed on
`attribute.ref/refs/heads/main`) replaces the repo-scoped principal
on the RW SA's `workloadIdentityUser` and `serviceAccountTokenCreator`
bindings. The RO SA stays on the repo-scoped `local.wif_principal`
so PR plan jobs still work.

## Gotchas

Once #63 ships, verify a `main`-triggered apply succeeds end-to-end
and a `workflow_dispatch` run from a non-main branch fails at the
STS step — that's the asymmetric check the issue's acceptance
criteria call for.

Closes #81