### PR TITLE
Document classic PAT for Projects sync token

### DIFF
--- a/.github/workflows/sync-project.yml
+++ b/.github/workflows/sync-project.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Run sync against github/projects/inbox.json
         env:
-          # Fine-grained PAT created out-of-band and pushed via
+          # Classic PAT created out-of-band and pushed via
           # scripts/configure-github-secrets.sh. One token serves every
           # board the script syncs. See
           # docs/how-to/create-github-project-sync-token.md for scopes.

--- a/.github/workflows/sync-project.yml
+++ b/.github/workflows/sync-project.yml
@@ -29,5 +29,5 @@ jobs:
           # scripts/configure-github-secrets.sh. One token serves every
           # board the script syncs. See
           # docs/how-to/create-github-project-sync-token.md for scopes.
-          GITHUB_PROJECT_SYNC_TOKEN: ${{ secrets.GITHUB_PROJECT_SYNC_TOKEN }}
+          GH_PROJECT_SYNC_TOKEN: ${{ secrets.GH_PROJECT_SYNC_TOKEN }}
         run: ./scripts/sync-project.sh github/projects/inbox.json

--- a/docs/how-to/create-github-project-sync-token.md
+++ b/docs/how-to/create-github-project-sync-token.md
@@ -9,27 +9,20 @@ both for first-time setup and for rotation.
 
 ## Generate the token
 
-1. Open <https://github.com/settings/tokens?type=beta>.
-2. Click **Generate new token**.
-3. Fill in:
-    - **Token name**: any (e.g. `alunduil-infrastructure-project-sync`).
-    - **Resource owner**: `alunduil`.
-    - **Expiration**: 1 year (the fine-grained cap).
-    - **Repository access**: **All repositories**.
-4. Under **Account permissions**, grant **Projects: Read and write**.
-5. Under **Repository permissions**, grant:
-    - **Metadata: Read**
-    - **Issues: Read**
-    - **Pull requests: Read**
-6. Click **Generate token** and copy the value.
+1. Open <https://github.com/settings/tokens> and click
+   **Generate new token (classic)**. A fine-grained token can't write
+   a user-owned Projects v2 board.
+2. **Note**: any (e.g. `alunduil-infrastructure-project-sync`).
+3. **Expiration**: 1 year.
+4. Select scopes:
+    - **`project`** — add and update board items.
+    - **`repo`** — read issues and pull requests across the board's
+      sources, private repos included.
+5. Click **Generate token** and copy the value.
 
-Every grant is read-only except **Projects: Read and write**, which
-the sync needs to add and update board items. **All repositories** is
-required because the board mirrors issues and pull requests you're
-assigned to across repos the token can't enumerate ahead of time;
-narrowing the repository access would silently drop those items. Keep
-this set on rotation — don't add **Contents** or other write scopes
-the sync doesn't use.
+Keep the scope set to `project` + `repo` on rotation. If
+`dungeon-studio` or `qua-world` restricts classic-token access in its
+org settings, approve this token there too or its items won't sync.
 
 ## Install the token
 

--- a/docs/how-to/create-github-project-sync-token.md
+++ b/docs/how-to/create-github-project-sync-token.md
@@ -4,7 +4,7 @@
 # Create the GitHub Projects sync PAT
 
 Generate and install the personal access token that the Projects
-sync workflow reads from `GITHUB_PROJECT_SYNC_TOKEN`. Follow this
+sync workflow reads from `GH_PROJECT_SYNC_TOKEN`. Follow this
 both for first-time setup and for rotation.
 
 ## Generate the token
@@ -29,7 +29,7 @@ org settings, approve this token there too or its items won't sync.
 Export the value and run the secrets script:
 
 ```sh
-export GITHUB_PROJECT_SYNC_TOKEN=<paste-here>
+export GH_PROJECT_SYNC_TOKEN=<paste-here>
 scripts/configure-github-secrets.sh
 ```
 

--- a/docs/how-to/create-github-project-sync-token.md
+++ b/docs/how-to/create-github-project-sync-token.md
@@ -18,9 +18,11 @@ both for first-time setup and for rotation.
     - **`project`** — add and update board items.
     - **`repo`** — read issues and pull requests across the board's
       sources, private repos included.
+    - **`read:org`** — resolve the org-owned sources; `gh project`
+      also needs it to look up the board's owner, even a user one.
 5. Click **Generate token** and copy the value.
 
-Keep the scope set to `project` + `repo` on rotation. If
+Keep the scope set to `project` + `repo` + `read:org` on rotation. If
 `dungeon-studio` or `qua-world` restricts classic-token access in its
 org settings, approve this token there too or its items won't sync.
 

--- a/scripts/configure-github-secrets.sh
+++ b/scripts/configure-github-secrets.sh
@@ -64,13 +64,13 @@ needs_key_prompt() {
 }
 
 needs_token_prompt() {
-  [[ -z "${GITHUB_PROJECT_SYNC_TOKEN:-}" ]] && ! has_env_secret "GITHUB_PROJECT_SYNC_TOKEN"
+  [[ -z "${GH_PROJECT_SYNC_TOKEN:-}" ]] && ! has_env_secret "GH_PROJECT_SYNC_TOKEN"
 }
 
 print_project_sync_token_pointer() {
   cat >&2 <<'EOF'
 
-GITHUB_PROJECT_SYNC_TOKEN authenticates the hourly Projects sync workflow.
+GH_PROJECT_SYNC_TOKEN authenticates the hourly Projects sync workflow.
 If you haven't created one yet, see
 docs/how-to/create-github-project-sync-token.md.
 
@@ -118,14 +118,14 @@ resolve_gh_app_private_key() {
 }
 
 resolve_project_sync_token() {
-  if [[ -n "${GITHUB_PROJECT_SYNC_TOKEN:-}" ]]; then
-    printf '%s' "${GITHUB_PROJECT_SYNC_TOKEN}"
-  elif has_env_secret "GITHUB_PROJECT_SYNC_TOKEN"; then # pragma: allowlist secret
-    echo "GITHUB_PROJECT_SYNC_TOKEN already set in the ${ENVIRONMENT} environment; leaving as-is" >&2
+  if [[ -n "${GH_PROJECT_SYNC_TOKEN:-}" ]]; then
+    printf '%s' "${GH_PROJECT_SYNC_TOKEN}"
+  elif has_env_secret "GH_PROJECT_SYNC_TOKEN"; then # pragma: allowlist secret
+    echo "GH_PROJECT_SYNC_TOKEN already set in the ${ENVIRONMENT} environment; leaving as-is" >&2
     printf '__KEEP__'
   else
     local value
-    read -r -s -p "Paste GITHUB_PROJECT_SYNC_TOKEN (input hidden, then press Enter): " value
+    read -r -s -p "Paste GH_PROJECT_SYNC_TOKEN (input hidden, then press Enter): " value
     echo >&2
     printf '%s' "${value}"
   fi
@@ -152,7 +152,7 @@ JSON
 
 GH_APP_ID_VALUE="$(resolve_gh_app_id)"
 GH_APP_PRIVATE_KEY_VALUE="$(resolve_gh_app_private_key)"
-GITHUB_PROJECT_SYNC_TOKEN_VALUE="$(resolve_project_sync_token)"
+GH_PROJECT_SYNC_TOKEN_VALUE="$(resolve_project_sync_token)"
 
 declare -A SECRETS=(
   [GCP_RO_WORKLOAD_IDENTITY_PROVIDER]="${WIF_PROVIDER}"
@@ -172,10 +172,10 @@ for name in "${!SECRETS[@]}"; do
 done
 
 ensure_environment
-if [[ "${GITHUB_PROJECT_SYNC_TOKEN_VALUE}" != "__KEEP__" ]]; then
-  echo "Setting secret: GITHUB_PROJECT_SYNC_TOKEN (environment: ${ENVIRONMENT})"
-  gh secret set GITHUB_PROJECT_SYNC_TOKEN --env "${ENVIRONMENT}" \
-    --body "${GITHUB_PROJECT_SYNC_TOKEN_VALUE}"
+if [[ "${GH_PROJECT_SYNC_TOKEN_VALUE}" != "__KEEP__" ]]; then
+  echo "Setting secret: GH_PROJECT_SYNC_TOKEN (environment: ${ENVIRONMENT})"
+  gh secret set GH_PROJECT_SYNC_TOKEN --env "${ENVIRONMENT}" \
+    --body "${GH_PROJECT_SYNC_TOKEN_VALUE}"
 fi
 
 echo

--- a/scripts/sync-project.sh
+++ b/scripts/sync-project.sh
@@ -18,7 +18,7 @@
 #   }
 #
 # Runs hourly from CI; safe to invoke locally — falls back to ambient
-# `gh` auth when GITHUB_PROJECT_SYNC_TOKEN is unset.
+# `gh` auth when GH_PROJECT_SYNC_TOKEN is unset.
 #
 # Steady-state cost: one item-list + one search per source-leg. Mutations
 # (item-add, item-edit) fire only for new URLs or stale filed-by values.
@@ -43,8 +43,8 @@ SEARCH_LIMIT=1000
 # Comfortable headroom above the current ~520 items on the largest board.
 PROJECT_LIMIT=5000
 
-if [[ -n ${GITHUB_PROJECT_SYNC_TOKEN:-} ]]; then
-  export GH_TOKEN=${GITHUB_PROJECT_SYNC_TOKEN}
+if [[ -n ${GH_PROJECT_SYNC_TOKEN:-} ]]; then
+  export GH_TOKEN=${GH_PROJECT_SYNC_TOKEN}
 fi
 
 # Resolve project and field IDs by title/name so disaster-recovery (board


### PR DESCRIPTION
## Summary

The hourly Projects sync has never run green: its sync token was never installable, for two independent reasons, and the documented scopes were short one entry. This PR fixes all three so the documented install path actually works end to end.

1. The how-to prescribed a fine-grained PAT with a Projects permission, but fine-grained PATs can't access a user-owned Projects v2 board. Rewritten for a classic token.
2. The secret was named `GITHUB_PROJECT_SYNC_TOKEN`, and GitHub reserves the `GITHUB_` prefix — `gh secret set` returns HTTP 422, so it could never be created. Renamed to `GH_PROJECT_SYNC_TOKEN` across the workflow, both scripts, and the how-to, matching the existing `GH_APP_*` convention.
3. The scope list was `project` + `repo`, but `gh project` resolves the board owner through organization data (even for a user-owned board) and the sync reads two org-owned sources, so it also needs `read:org`. Without it, owner resolution fails with the opaque `unknown owner type`. Added.

## Why `repo`, despite the breadth

Classic tokens have no read-only-private scope — `repo` is the floor for reading issues/PRs across all three board sources (`alunduil` plus the `dungeon-studio` / `qua-world` orgs) in one credential. Considered and rejected:

- `public_repo` — silently drops every private item.
- `project`-only PAT + the existing GitHub App for reads — the App key mints Administration + Contents read/write tokens and authenticates Terraform, so handing it to an hourly job widens the blast radius of the crown-jewel key and gives a compromised runner a pivot into IaC. It's also installed only on the personal account, so it can't read the two orgs anyway.
- Re-homing the board under an org for fine-grained reads — cleaner in principle, but the cross-org read fragmentation hits that path too. Deferred; relates to #90.

Final classic scope set: `project` + `repo` + `read:org`. The `repo` breadth is accepted as the interim posture; revisit alongside the declarative replacement in #90.

## Gotchas

No `.tf` and no apply-time behavior change — workflow, helper scripts, and docs only. The fix that turns CI green is installing the token out-of-band (see the rewritten how-to); this PR only makes the instructions followable, the secret name valid, and the scope list complete.

## Verification

- Confirmed the root cause directly: the `project-sync` environment had zero secrets, so the workflow ran `gh` with an empty token and exited 4.
- Confirmed the rename is necessary by hitting the live HTTP 422 (`Secret names must not start with GITHUB_`) during install.
- Diagnosed the `read:org` gap from the scope delta between a working keyring token (`project`, `read:org`, `repo`) and a `project`+`repo`-only PAT that failed owner resolution with `unknown owner type`.
- pre-commit (shellcheck, shfmt, markdownlint, yamllint, reuse, detect-secrets) green on all touched files.
- Token install and the first green run happen out-of-band post-merge.