### PR TITLE
Set Inbox board Status by item type on sync

### DIFF
--- a/github/projects/inbox.json
+++ b/github/projects/inbox.json
@@ -32,6 +32,9 @@
     }
   ],
   "filed_by_field": "Filed by",
+  "status_field": "Status",
+  "pr_status": "Review",
+  "issue_status": "Backlog",
   "sources": [
     { "type": "owner", "logins": ["alunduil", "dungeon-studio", "qua-world"] },
     { "type": "author", "login": "alunduil" },

--- a/github/projects/project.schema.json
+++ b/github/projects/project.schema.json
@@ -32,6 +32,21 @@
       "description": "Name of the TEXT field the #73 sync workflow stamps with each item's source. Consumed by sync-project.sh, not by bootstrap.sh; should name a field declared in `fields`.",
       "minLength": 1
     },
+    "status_field": {
+      "type": "string",
+      "description": "Name of the SINGLE_SELECT field the #73 sync workflow sets per item type. Consumed by sync-project.sh, not by bootstrap.sh; should name a field declared in `fields`. Requires `pr_status` and `issue_status`.",
+      "minLength": 1
+    },
+    "pr_status": {
+      "type": "string",
+      "description": "Option name in `status_field` assigned to pull requests. Consumed by sync-project.sh; must match an option declared on that field.",
+      "minLength": 1
+    },
+    "issue_status": {
+      "type": "string",
+      "description": "Option name in `status_field` assigned to issues. Consumed by sync-project.sh; must match an option declared on that field.",
+      "minLength": 1
+    },
     "sources": {
       "type": "array",
       "description": "Issue/PR sources the #73 sync workflow mirrors into the board. Consumed by sync-project.sh, not by bootstrap.sh.",

--- a/scripts/sync-project.bats
+++ b/scripts/sync-project.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+#
+# Unit tests for the pure helpers in sync-project.sh (desired_status,
+# parse_items). Network-touching code paths are not exercised — they're
+# covered by running the script against the live Inbox project, which
+# alunduil performs out-of-band.
+
+# shellcheck disable=SC2034 # these globals are read by the sourced helpers
+setup() {
+  # parse_items keys field values by these names; desired_status maps the
+  # item type to these option ids/names. Set before any helper is called.
+  FILED_BY_FIELD_NAME='Filed by'
+  STATUS_FIELD_NAME='Status'
+  PR_STATUS_OPTION_ID='rev0'
+  PR_STATUS_NAME='Review'
+  ISSUE_STATUS_OPTION_ID='bak0'
+  ISSUE_STATUS_NAME='Backlog'
+  # shellcheck source=sync-project.sh disable=SC1091
+  source "${BATS_TEST_DIRNAME}/sync-project.sh"
+}
+
+# --- desired_status -------------------------------------------------------
+
+@test "desired_status routes a pull-request url to pr_status" {
+  run desired_status "https://github.com/o/r/pull/7"
+  [[ $output == $'rev0\tReview' ]]
+}
+
+@test "desired_status routes an issue url to issue_status" {
+  run desired_status "https://github.com/o/r/issues/7"
+  [[ $output == $'bak0\tBacklog' ]]
+}
+
+@test "desired_status keys on the /pull/ path segment, not the substring" {
+  # A repo whose name contains 'pull' must not be mistaken for a PR.
+  run desired_status "https://github.com/o/pull-mirror/issues/7"
+  [[ $output == $'bak0\tBacklog' ]]
+}
+
+# --- parse_items ----------------------------------------------------------
+
+# Minimal shape of a `node(id:){ items{ nodes } }` GraphQL response.
+items_response() {
+  printf '{"data":{"node":{"items":{"nodes":[%s]}}}}' "$1"
+}
+
+@test "parse_items emits url, filed-by, status, and id" {
+  json=$(items_response '
+    {"id":"i1","content":{"url":"https://github.com/o/r/pull/1"},
+     "fieldValues":{"nodes":[
+       {"text":"alunduil","field":{"name":"Filed by"}},
+       {"name":"Review","field":{"name":"Status"}}]}}')
+  run parse_items <<<"$json"
+  [[ $output == $'https://github.com/o/r/pull/1\talunduil\tReview\ti1' ]]
+}
+
+@test "parse_items defaults a missing status to empty" {
+  json=$(items_response '
+    {"id":"i2","content":{"url":"https://github.com/o/r/issues/2"},
+     "fieldValues":{"nodes":[
+       {"text":"alunduil","field":{"name":"Filed by"}}]}}')
+  run parse_items <<<"$json"
+  [[ $output == $'https://github.com/o/r/issues/2\talunduil\t\ti2' ]]
+}
+
+@test "parse_items defaults a missing filed-by to empty" {
+  json=$(items_response '
+    {"id":"i3","content":{"url":"https://github.com/o/r/issues/3"},
+     "fieldValues":{"nodes":[
+       {"name":"Backlog","field":{"name":"Status"}}]}}')
+  run parse_items <<<"$json"
+  [[ $output == $'https://github.com/o/r/issues/3\t\tBacklog\ti3' ]]
+}
+
+@test "parse_items skips items without a content url (draft items)" {
+  json=$(items_response '
+    {"id":"i4","content":{},"fieldValues":{"nodes":[]}},
+    {"id":"i5","content":{"url":"https://github.com/o/r/issues/5"},
+     "fieldValues":{"nodes":[]}}')
+  run parse_items <<<"$json"
+  [[ $output == $'https://github.com/o/r/issues/5\t\t\ti5' ]]
+}
+
+@test "parse_items ignores field values from other fields" {
+  json=$(items_response '
+    {"id":"i6","content":{"url":"https://github.com/o/r/pull/6"},
+     "fieldValues":{"nodes":[
+       {"text":"Some Title","field":{"name":"Title"}},
+       {"text":"alunduil","field":{"name":"Filed by"}},
+       {"name":"Review","field":{"name":"Status"}}]}}')
+  run parse_items <<<"$json"
+  [[ $output == $'https://github.com/o/r/pull/6\talunduil\tReview\ti6' ]]
+}

--- a/scripts/sync-project.sh
+++ b/scripts/sync-project.sh
@@ -4,12 +4,16 @@
 
 # Mirror open issues/PRs from a set of GitHub search queries onto a
 # Projects v2 board, populating a configured text field with the author
-# login. Reads a JSON spec from scripts/sync-specs/<board>.json:
+# login and a single-select Status by item type. Reads a JSON spec from
+# github/projects/<board>.json:
 #
 #   {
 #     "owner": "alunduil",
 #     "title": "Inbox",
 #     "filed_by_field": "Filed by",
+#     "status_field": "Status",
+#     "pr_status": "Review",
+#     "issue_status": "Backlog",
 #     "sources": [
 #       { "type": "owner", "logins": [...] },
 #       { "type": "author", "login": "..." },
@@ -17,11 +21,18 @@
 #     ]
 #   }
 #
+# Status handling is opt-in: omit status_field to leave Status untouched.
+# When set, the script is authoritative — open PRs are forced to pr_status
+# and open issues to issue_status on every run, so it self-heals drift
+# rather than deferring to GitHub's built-in "item added" workflow (which
+# can't tell a PR from an issue and so lands everything in one column).
+#
 # Runs hourly from CI; safe to invoke locally — falls back to ambient
 # `gh` auth when GH_PROJECT_SYNC_TOKEN is unset.
 #
 # Steady-state cost: one item-list + one search per source-leg. Mutations
-# (item-add, item-edit) fire only for new URLs or stale filed-by values.
+# (item-add, item-edit) fire only for new URLs, stale filed-by values, or
+# items whose Status doesn't match their type.
 
 set -euo pipefail
 
@@ -39,6 +50,7 @@ SPEC=$1
 PROJECT_OWNER=$(jq -r '.owner' "${SPEC}")
 PROJECT_TITLE=$(jq -r '.title' "${SPEC}")
 FILED_BY_FIELD_NAME=$(jq -r '.filed_by_field' "${SPEC}")
+STATUS_FIELD_NAME=$(jq -r '.status_field // empty' "${SPEC}")
 SEARCH_LIMIT=1000
 # Comfortable headroom above the current ~520 items on the largest board.
 PROJECT_LIMIT=5000
@@ -73,16 +85,62 @@ fi
 # `gh project item-list` lower-cases custom field names as JSON keys.
 filed_by_key=${FILED_BY_FIELD_NAME,,}
 
-declare -A existing_id existing_filed
+# Status sync is opt-in. When status_field is set, resolve the field and
+# the per-type option IDs up front so the item loop is a pure ID lookup.
+if [[ -n ${STATUS_FIELD_NAME} ]]; then
+  PR_STATUS_NAME=$(jq -r '.pr_status // empty' "${SPEC}")
+  ISSUE_STATUS_NAME=$(jq -r '.issue_status // empty' "${SPEC}")
+  if [[ -z ${PR_STATUS_NAME} || -z ${ISSUE_STATUS_NAME} ]]; then
+    echo "status_field '${STATUS_FIELD_NAME}' requires both pr_status and issue_status" >&2
+    exit 1
+  fi
 
-while IFS=$'\t' read -r url filed item_id; do
+  status_field_json=$(
+    gh project field-list "${PROJECT_NUMBER}" --owner "${PROJECT_OWNER}" \
+      --format json \
+      --jq ".fields | map(select(.name == \"${STATUS_FIELD_NAME}\"))[0]"
+  )
+  STATUS_FIELD_ID=$(jq -r '.id // empty' <<<"${status_field_json}")
+  if [[ -z ${STATUS_FIELD_ID} ]]; then
+    echo "no field named '${STATUS_FIELD_NAME}' on project '${PROJECT_TITLE}'" >&2
+    exit 1
+  fi
+  PR_STATUS_OPTION_ID=$(jq -r --arg n "${PR_STATUS_NAME}" '.options[] | select(.name == $n) | .id' <<<"${status_field_json}")
+  ISSUE_STATUS_OPTION_ID=$(jq -r --arg n "${ISSUE_STATUS_NAME}" '.options[] | select(.name == $n) | .id' <<<"${status_field_json}")
+  if [[ -z ${PR_STATUS_OPTION_ID} || -z ${ISSUE_STATUS_OPTION_ID} ]]; then
+    echo "field '${STATUS_FIELD_NAME}' is missing option '${PR_STATUS_NAME}' or '${ISSUE_STATUS_NAME}'" >&2
+    exit 1
+  fi
+  status_key=${STATUS_FIELD_NAME,,}
+fi
+
+# Emit the desired Status option id + name for a URL: PRs (/pull/) take
+# pr_status, everything else issue_status. Tab-separated for `read`.
+desired_status() {
+  if [[ $1 == */pull/* ]]; then
+    printf '%s\t%s' "${PR_STATUS_OPTION_ID}" "${PR_STATUS_NAME}"
+  else
+    printf '%s\t%s' "${ISSUE_STATUS_OPTION_ID}" "${ISSUE_STATUS_NAME}"
+  fi
+}
+
+declare -A existing_id existing_filed existing_status
+
+if [[ -n ${STATUS_FIELD_NAME} ]]; then
+  status_jq="(.[\"${status_key}\"] // \"\")"
+else
+  status_jq='""'
+fi
+
+while IFS=$'\t' read -r url filed status item_id; do
   [[ -z $url ]] && continue
   existing_id[$url]=$item_id
   existing_filed[$url]=$filed
+  existing_status[$url]=$status
 done < <(
   gh project item-list "${PROJECT_NUMBER}" --owner "${PROJECT_OWNER}" \
     --format json --limit "${PROJECT_LIMIT}" \
-    --jq ".items[] | select(.content.url) | \"\\(.content.url)\\t\\(.[\"${filed_by_key}\"] // \"\")\\t\\(.id)\""
+    --jq ".items[] | select(.content.url) | \"\\(.content.url)\\t\\(.[\"${filed_by_key}\"] // \"\")\\t${status_jq}\\t\\(.id)\""
 )
 
 jq_pair='.[] | "\(.url)\t\(.author.login // "unknown")"'
@@ -114,6 +172,10 @@ updated=0
 skipped=0
 
 while IFS=$'\t' read -r url author; do
+  if [[ -n ${STATUS_FIELD_NAME} ]]; then
+    IFS=$'\t' read -r want_status_id want_status_name < <(desired_status "$url")
+  fi
+
   if [[ -z ${existing_id[$url]:-} ]]; then
     printf 'adding %s (filed by %s)\n' "$url" "$author"
     item_id=$(
@@ -126,8 +188,19 @@ while IFS=$'\t' read -r url author; do
       --id "$item_id" \
       --field-id "${FILED_BY_FIELD_ID}" \
       --text "$author" >/dev/null
+    if [[ -n ${STATUS_FIELD_NAME} ]]; then
+      gh project item-edit \
+        --project-id "${PROJECT_ID}" \
+        --id "$item_id" \
+        --field-id "${STATUS_FIELD_ID}" \
+        --single-select-option-id "${want_status_id}" >/dev/null
+    fi
     added=$((added + 1))
-  elif [[ ${existing_filed[$url]} != "$author" ]]; then
+    continue
+  fi
+
+  changed=0
+  if [[ ${existing_filed[$url]} != "$author" ]]; then
     printf 'updating filed by on %s (%s -> %s)\n' \
       "$url" "${existing_filed[$url]}" "$author"
     gh project item-edit \
@@ -135,6 +208,19 @@ while IFS=$'\t' read -r url author; do
       --id "${existing_id[$url]}" \
       --field-id "${FILED_BY_FIELD_ID}" \
       --text "$author" >/dev/null
+    changed=1
+  fi
+  if [[ -n ${STATUS_FIELD_NAME} && ${existing_status[$url]} != "$want_status_name" ]]; then
+    printf 'updating status on %s (%s -> %s)\n' \
+      "$url" "${existing_status[$url]:-<none>}" "$want_status_name"
+    gh project item-edit \
+      --project-id "${PROJECT_ID}" \
+      --id "${existing_id[$url]}" \
+      --field-id "${STATUS_FIELD_ID}" \
+      --single-select-option-id "${want_status_id}" >/dev/null
+    changed=1
+  fi
+  if [[ $changed -eq 1 ]]; then
     updated=$((updated + 1))
   else
     skipped=$((skipped + 1))

--- a/scripts/sync-project.sh
+++ b/scripts/sync-project.sh
@@ -41,6 +41,94 @@
 
 set -euo pipefail
 
+# Desired Status option id + name for a URL: PRs (/pull/) take pr_status,
+# everything else issue_status. Tab-separated for `read`.
+desired_status() {
+  if [[ $1 == */pull/* ]]; then
+    printf '%s\t%s' "${PR_STATUS_OPTION_ID}" "${PR_STATUS_NAME}"
+  else
+    printf '%s\t%s' "${ISSUE_STATUS_OPTION_ID}" "${ISSUE_STATUS_NAME}"
+  fi
+}
+
+# Read a project-items GraphQL response on stdin and emit one
+# url<TAB>filed<TAB>status<TAB>item-id row per item that has a content URL.
+# An item with no value for a field omits it from fieldValues, hence the
+# empty-string defaults (which match the "" used in the comparisons below).
+parse_items() {
+  jq -r --arg filed "${FILED_BY_FIELD_NAME}" --arg status "${STATUS_FIELD_NAME}" '
+    .data.node.items.nodes[]
+    | select(.content.url)
+    | [ .content.url,
+        ([.fieldValues.nodes[]? | select(.field.name == $filed) | .text] | first // ""),
+        ([.fieldValues.nodes[]? | select(.field.name == $status) | .name] | first // ""),
+        .id ]
+    | @tsv'
+}
+
+# Mirror the board, paginating the project node and pulling only the two
+# field values the sync acts on; see the header for why this beats
+# `gh project item-list`.
+board_items() {
+  local cursor="" resp
+  while :; do
+    # shellcheck disable=SC2016 # $id/$cursor are GraphQL variables, not shell
+    resp=$(
+      gh api graphql -F id="${PROJECT_ID}" -F cursor="${cursor}" -f query='
+        query($id: ID!, $cursor: String) {
+          node(id: $id) {
+            ... on ProjectV2 {
+              items(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  id
+                  content { ... on Issue { url } ... on PullRequest { url } }
+                  fieldValues(first: 8) {
+                    nodes {
+                      ... on ProjectV2ItemFieldTextValue { text field { ... on ProjectV2FieldCommon { name } } }
+                      ... on ProjectV2ItemFieldSingleSelectValue { name field { ... on ProjectV2FieldCommon { name } } }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }'
+    )
+    parse_items <<<"${resp}"
+    [[ $(jq -r '.data.node.items.pageInfo.hasNextPage' <<<"${resp}") == true ]] || break
+    cursor=$(jq -r '.data.node.items.pageInfo.endCursor' <<<"${resp}")
+  done
+}
+
+# Emit one gh-search argument string per source-leg. Two legs per source
+# (issues + prs). The trailing word-split on $leg in the consumer is
+# intentional; arguments are jq-controlled, not user input.
+search_legs() {
+  jq -r '
+    .sources[] |
+    if .type == "owner" then
+      ([.logins[] | "--owner=" + .] | join(" ")) as $owners |
+      "issues " + $owners,
+      "prs " + $owners
+    elif .type == "author" then
+      "issues --author=" + .login,
+      "prs --author=" + .login
+    elif .type == "assignee" then
+      "issues --assignee=" + .login,
+      "prs --assignee=" + .login
+    else
+      error("unknown source type: " + .type)
+    end
+  ' "${SPEC}"
+}
+
+# Skip the executable body when sourced (e.g. by sync-project.bats).
+if [[ ${BASH_SOURCE[0]} != "${0}" ]]; then
+  # shellcheck disable=SC2317 # reached only when sourced, which shellcheck can't see
+  return 0 2>/dev/null || true
+fi
+
 if [[ $# -ne 1 ]]; then
   echo "usage: $0 <spec.json>" >&2
   exit 64
@@ -128,60 +216,6 @@ if [[ -n ${STATUS_FIELD_NAME} ]]; then
   fi
 fi
 
-# Emit the desired Status option id + name for a URL: PRs (/pull/) take
-# pr_status, everything else issue_status. Tab-separated for `read`.
-desired_status() {
-  if [[ $1 == */pull/* ]]; then
-    printf '%s\t%s' "${PR_STATUS_OPTION_ID}" "${PR_STATUS_NAME}"
-  else
-    printf '%s\t%s' "${ISSUE_STATUS_OPTION_ID}" "${ISSUE_STATUS_NAME}"
-  fi
-}
-
-# Mirror the board as url<TAB>filed<TAB>status<TAB>item-id, paginating the
-# project node and pulling only the two field values we act on. An item
-# with no value for a field simply omits it, hence the empty-string
-# defaults (which also match the "" used in the comparisons below).
-board_items() {
-  local cursor="" resp
-  while :; do
-    # shellcheck disable=SC2016 # $id/$cursor are GraphQL variables, not shell
-    resp=$(
-      gh api graphql -F id="${PROJECT_ID}" -F cursor="${cursor}" -f query='
-        query($id: ID!, $cursor: String) {
-          node(id: $id) {
-            ... on ProjectV2 {
-              items(first: 100, after: $cursor) {
-                pageInfo { hasNextPage endCursor }
-                nodes {
-                  id
-                  content { ... on Issue { url } ... on PullRequest { url } }
-                  fieldValues(first: 8) {
-                    nodes {
-                      ... on ProjectV2ItemFieldTextValue { text field { ... on ProjectV2FieldCommon { name } } }
-                      ... on ProjectV2ItemFieldSingleSelectValue { name field { ... on ProjectV2FieldCommon { name } } }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }'
-    )
-    jq -r --arg filed "${FILED_BY_FIELD_NAME}" --arg status "${STATUS_FIELD_NAME}" '
-      .data.node.items.nodes[]
-      | select(.content.url)
-      | [ .content.url,
-          ([.fieldValues.nodes[]? | select(.field.name == $filed) | .text] | first // ""),
-          ([.fieldValues.nodes[]? | select(.field.name == $status) | .name] | first // ""),
-          .id ]
-      | @tsv
-    ' <<<"${resp}"
-    [[ $(jq -r '.data.node.items.pageInfo.hasNextPage' <<<"${resp}") == true ]] || break
-    cursor=$(jq -r '.data.node.items.pageInfo.endCursor' <<<"${resp}")
-  done
-}
-
 declare -A existing_id existing_filed existing_status
 while IFS=$'\t' read -r url filed status item_id; do
   [[ -z $url ]] && continue
@@ -191,28 +225,6 @@ while IFS=$'\t' read -r url filed status item_id; do
 done < <(board_items)
 
 jq_pair='.[] | "\(.url)\t\(.author.login // "unknown")"'
-
-# Emit one gh-search argument string per source-leg. Two legs per source
-# (issues + prs). The trailing word-split on $leg in the consumer is
-# intentional; arguments are jq-controlled, not user input.
-search_legs() {
-  jq -r '
-    .sources[] |
-    if .type == "owner" then
-      ([.logins[] | "--owner=" + .] | join(" ")) as $owners |
-      "issues " + $owners,
-      "prs " + $owners
-    elif .type == "author" then
-      "issues --author=" + .login,
-      "prs --author=" + .login
-    elif .type == "assignee" then
-      "issues --assignee=" + .login,
-      "prs --assignee=" + .login
-    else
-      error("unknown source type: " + .type)
-    end
-  ' "${SPEC}"
-}
 
 added=0
 updated=0

--- a/scripts/sync-project.sh
+++ b/scripts/sync-project.sh
@@ -30,9 +30,14 @@
 # Runs hourly from CI; safe to invoke locally — falls back to ambient
 # `gh` auth when GH_PROJECT_SYNC_TOKEN is unset.
 #
-# Steady-state cost: one item-list + one search per source-leg. Mutations
-# (item-add, item-edit) fire only for new URLs, stale filed-by values, or
-# items whose Status doesn't match their type.
+# Steady-state cost: a paginated read of the board node plus one search
+# per source-leg. Mutations (item-add, item-edit) fire only for new URLs,
+# stale filed-by values, or items whose Status doesn't match their type.
+#
+# Reads go through hand-written GraphQL rather than `gh project
+# field-list`/`item-list`: the porcelain over-fetches every field of every
+# item (~100 GraphQL points per field-list, ~1 per item), and there is no
+# flag to trim it. The lean queries below cost ~1 point per 100-item page.
 
 set -euo pipefail
 
@@ -52,15 +57,13 @@ PROJECT_TITLE=$(jq -r '.title' "${SPEC}")
 FILED_BY_FIELD_NAME=$(jq -r '.filed_by_field' "${SPEC}")
 STATUS_FIELD_NAME=$(jq -r '.status_field // empty' "${SPEC}")
 SEARCH_LIMIT=1000
-# Comfortable headroom above the current ~520 items on the largest board.
-PROJECT_LIMIT=5000
 
 if [[ -n ${GH_PROJECT_SYNC_TOKEN:-} ]]; then
   export GH_TOKEN=${GH_PROJECT_SYNC_TOKEN}
 fi
 
-# Resolve project and field IDs by title/name so disaster-recovery (board
-# recreation) doesn't strand this script.
+# Resolve the project by title so disaster-recovery (board recreation)
+# doesn't strand this script on a hard-coded number.
 project_match=$(
   gh project list --owner "${PROJECT_OWNER}" --limit 100 --format json \
     --jq ".projects | map(select(.title == \"${PROJECT_TITLE}\"))"
@@ -72,18 +75,33 @@ fi
 PROJECT_ID=$(jq -r '.[0].id' <<<"${project_match}")
 PROJECT_NUMBER=$(jq -r '.[0].number' <<<"${project_match}")
 
-FILED_BY_FIELD_ID=$(
-  gh project field-list "${PROJECT_NUMBER}" --owner "${PROJECT_OWNER}" \
-    --format json \
-    --jq ".fields | map(select(.name == \"${FILED_BY_FIELD_NAME}\"))[0].id"
+# Field IDs (and single-select option IDs) come from one lean GraphQL
+# query on the opaque project node ID, which works whether the owner is a
+# user or an org. Resolved once here; the item loop is then a pure lookup.
+fields_json=$(
+  # shellcheck disable=SC2016 # $id is a GraphQL variable, not shell
+  gh api graphql -F id="${PROJECT_ID}" --jq '.data.node.fields.nodes' -f query='
+    query($id: ID!) {
+      node(id: $id) {
+        ... on ProjectV2 {
+          fields(first: 50) {
+            nodes {
+              __typename
+              ... on ProjectV2FieldCommon { id name }
+              ... on ProjectV2SingleSelectField { id name options { id name } }
+            }
+          }
+        }
+      }
+    }'
 )
-if [[ -z ${FILED_BY_FIELD_ID} || ${FILED_BY_FIELD_ID} == null ]]; then
+
+FILED_BY_FIELD_ID=$(jq -r --arg n "${FILED_BY_FIELD_NAME}" \
+  'map(select(.name == $n))[0].id // empty' <<<"${fields_json}")
+if [[ -z ${FILED_BY_FIELD_ID} ]]; then
   echo "no field named '${FILED_BY_FIELD_NAME}' on project '${PROJECT_TITLE}'" >&2
   exit 1
 fi
-
-# `gh project item-list` lower-cases custom field names as JSON keys.
-filed_by_key=${FILED_BY_FIELD_NAME,,}
 
 # Status sync is opt-in. When status_field is set, resolve the field and
 # the per-type option IDs up front so the item loop is a pure ID lookup.
@@ -95,11 +113,8 @@ if [[ -n ${STATUS_FIELD_NAME} ]]; then
     exit 1
   fi
 
-  status_field_json=$(
-    gh project field-list "${PROJECT_NUMBER}" --owner "${PROJECT_OWNER}" \
-      --format json \
-      --jq ".fields | map(select(.name == \"${STATUS_FIELD_NAME}\"))[0]"
-  )
+  status_field_json=$(jq --arg n "${STATUS_FIELD_NAME}" \
+    'map(select(.name == $n))[0]' <<<"${fields_json}")
   STATUS_FIELD_ID=$(jq -r '.id // empty' <<<"${status_field_json}")
   if [[ -z ${STATUS_FIELD_ID} ]]; then
     echo "no field named '${STATUS_FIELD_NAME}' on project '${PROJECT_TITLE}'" >&2
@@ -111,7 +126,6 @@ if [[ -n ${STATUS_FIELD_NAME} ]]; then
     echo "field '${STATUS_FIELD_NAME}' is missing option '${PR_STATUS_NAME}' or '${ISSUE_STATUS_NAME}'" >&2
     exit 1
   fi
-  status_key=${STATUS_FIELD_NAME,,}
 fi
 
 # Emit the desired Status option id + name for a URL: PRs (/pull/) take
@@ -124,24 +138,57 @@ desired_status() {
   fi
 }
 
+# Mirror the board as url<TAB>filed<TAB>status<TAB>item-id, paginating the
+# project node and pulling only the two field values we act on. An item
+# with no value for a field simply omits it, hence the empty-string
+# defaults (which also match the "" used in the comparisons below).
+board_items() {
+  local cursor="" resp
+  while :; do
+    # shellcheck disable=SC2016 # $id/$cursor are GraphQL variables, not shell
+    resp=$(
+      gh api graphql -F id="${PROJECT_ID}" -F cursor="${cursor}" -f query='
+        query($id: ID!, $cursor: String) {
+          node(id: $id) {
+            ... on ProjectV2 {
+              items(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  id
+                  content { ... on Issue { url } ... on PullRequest { url } }
+                  fieldValues(first: 8) {
+                    nodes {
+                      ... on ProjectV2ItemFieldTextValue { text field { ... on ProjectV2FieldCommon { name } } }
+                      ... on ProjectV2ItemFieldSingleSelectValue { name field { ... on ProjectV2FieldCommon { name } } }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }'
+    )
+    jq -r --arg filed "${FILED_BY_FIELD_NAME}" --arg status "${STATUS_FIELD_NAME}" '
+      .data.node.items.nodes[]
+      | select(.content.url)
+      | [ .content.url,
+          ([.fieldValues.nodes[]? | select(.field.name == $filed) | .text] | first // ""),
+          ([.fieldValues.nodes[]? | select(.field.name == $status) | .name] | first // ""),
+          .id ]
+      | @tsv
+    ' <<<"${resp}"
+    [[ $(jq -r '.data.node.items.pageInfo.hasNextPage' <<<"${resp}") == true ]] || break
+    cursor=$(jq -r '.data.node.items.pageInfo.endCursor' <<<"${resp}")
+  done
+}
+
 declare -A existing_id existing_filed existing_status
-
-if [[ -n ${STATUS_FIELD_NAME} ]]; then
-  status_jq="(.[\"${status_key}\"] // \"\")"
-else
-  status_jq='""'
-fi
-
 while IFS=$'\t' read -r url filed status item_id; do
   [[ -z $url ]] && continue
   existing_id[$url]=$item_id
   existing_filed[$url]=$filed
   existing_status[$url]=$status
-done < <(
-  gh project item-list "${PROJECT_NUMBER}" --owner "${PROJECT_OWNER}" \
-    --format json --limit "${PROJECT_LIMIT}" \
-    --jq ".items[] | select(.content.url) | \"\\(.content.url)\\t\\(.[\"${filed_by_key}\"] // \"\")\\t${status_jq}\\t\\(.id)\""
-)
+done < <(board_items)
 
 jq_pair='.[] | "\(.url)\t\(.author.login // "unknown")"'
 


### PR DESCRIPTION
## Summary

Open PRs now land in the Inbox board's **Review** column instead of **Backlog**, and the hourly sync that places them costs ~36× less GraphQL budget. The sync only stamped Filed-by and left Status to GitHub's built-in "item added" workflow, which can't tell a PR from an issue — so every new item landed in Backlog regardless of type, and 195 issues had no status at all. The script now owns Status (open PRs → Review, open issues → Backlog, reconciled every run) and reads the board with hand-written GraphQL instead of `gh project` porcelain, which over-fetched every field of every item.

## Gotchas

Three changes in one file (plus a new test file):

- **Status reconcile semantics** — when `status_field` is set the script is authoritative and overwrites Status on every hourly run, so a deliberate manual column move on an open PR/issue gets reverted next cycle. Intended (the board's three columns are a pure function of item type + open/closed), but it's the one behavioral edge worth a look. Status handling stays opt-in — omit `status_field` and the script leaves Status alone.
- **GraphQL read rewrite** — the cost win. `gh project field-list`/`item-list` cost ~100 and ~800 GraphQL points because the porcelain requests `fieldValues(first:100)` nested in `items(first:100)` and GitHub's cost formula multiplies nested connections; there's no flag to trim it. Reads now go through `node(id:)` queries (owner-type agnostic, so user/org generality is kept) pulling only the two field values the sync touches.
- **Sourceable refactor** — `sync-project.sh` now defines its helpers ahead of the executable body and guards on `BASH_SOURCE`, matching `bootstrap.sh`, so the pure functions can be unit-tested. No behavior change to the run path.

The schema gained `status_field`/`pr_status`/`issue_status`; `additionalProperties: false` means spec and schema move together.

## Verification

- New `scripts/sync-project.bats` (8 tests, run via `bats`) covers the two decisions this script owns: the `/pull/` vs issue routing (keyed on the path segment, not a substring) and `parse_items`' field extraction with empty-string defaults. Mirrors `bootstrap.bats`; like it, bats is developer-run, not a CI gate (automating that is tracked in #127).
- New GraphQL read output diffed **byte-identical** to the old `gh project item-list` across all 716 board items, and `board_items` returns the same 716 rows after the refactor — behavior unchanged.
- Measured live: full board read dropped from ~809 to ~21 GraphQL points; a full run from ~1,018 to ~28 (~24k/day → ~670/day).
- `pre-commit` (shellcheck, shfmt, check-jsonschema) green on all changed files.
- One-time backfill already applied out-of-band: the 25 open PRs in Backlog (plus one statusless PR) moved to Review; board shows 30 open PRs in Review, 0 in Backlog, closed items untouched.
- PR 326 (the original trigger) merged before the fix landed, so it's correctly Closed and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)