### PR TITLE
Fix sync-project aborting on the first item under set -e

### DIFF
--- a/scripts/sync-project.bats
+++ b/scripts/sync-project.bats
@@ -39,6 +39,16 @@ setup() {
   [[ $output == $'bak0\tBacklog' ]]
 }
 
+@test "desired_status is newline-terminated so the per-item read returns 0" {
+  # Regression: desired_status emitted no trailing newline, so the reconcile
+  # loop's `read` hit EOF and returned 1, aborting the script under set -e on
+  # the first item. The read must succeed and populate both fields.
+  rc=0
+  IFS=$'\t' read -r id name < <(desired_status "https://github.com/o/r/issues/9") || rc=$?
+  [[ $rc -eq 0 ]]
+  [[ $id == bak0 && $name == Backlog ]]
+}
+
 # --- parse_items ----------------------------------------------------------
 
 # Minimal shape of a `node(id:){ items{ nodes } }` GraphQL response.

--- a/scripts/sync-project.sh
+++ b/scripts/sync-project.sh
@@ -48,12 +48,14 @@
 set -Eeuo pipefail
 
 # Desired Status option id + name for a URL: PRs (/pull/) take pr_status,
-# everything else issue_status. Tab-separated for `read`.
+# everything else issue_status. Tab-separated, newline-terminated so the
+# consuming `read` returns 0 (a line without a trailing newline makes `read`
+# hit EOF and exit 1, which aborts the loop under `set -e`).
 desired_status() {
   if [[ $1 == */pull/* ]]; then
-    printf '%s\t%s' "${PR_STATUS_OPTION_ID}" "${PR_STATUS_NAME}"
+    printf '%s\t%s\n' "${PR_STATUS_OPTION_ID}" "${PR_STATUS_NAME}"
   else
-    printf '%s\t%s' "${ISSUE_STATUS_OPTION_ID}" "${ISSUE_STATUS_NAME}"
+    printf '%s\t%s\n' "${ISSUE_STATUS_OPTION_ID}" "${ISSUE_STATUS_NAME}"
   fi
 }
 


### PR DESCRIPTION
## Summary

The hourly `sync-project` job has been failing on essentially every run with real search results since #123. The CI tracing added in #130 pinned the abort to one line in the reconcile loop.

`desired_status` emitted its tab-separated pair with `printf '%s\t%s'` — **no trailing newline**. The loop consumes it with a standalone:

```bash
IFS=$'\t' read -r want_status_id want_status_name < <(desired_status "$url")
```

When `read` reaches EOF without a line delimiter it returns **exit status 1** (while still assigning the variables). That `read` isn't a loop condition or part of an `&&`/`||` list, so it isn't exempt from `set -e`, and the script aborted on the **first item** the loop processed — before any board mutation.

## Trace that identified it

From the 15:32 UTC run (commit `612e5f0`, with #130's tracing):

```
+ sync-project.sh:259: read -r want_status_id want_status_name
++ sync-project.sh:56:  printf '%s\t%s' 8080c408 Backlog
++ sync-project.sh:259: rc=1
sync-project: failed (exit 1) at sync-project.sh:259: IFS='\t' read -r want_status_id want_status_name < <(desired_status "$url")
```

It dies on the very first URL, well before any `gh` mutation — which ruled out the earlier rate-limit hypothesis. The occasional green run (e.g. 12:36) was one where the searches transiently returned nothing, so the loop body never executed.

## Fix

Terminate `desired_status` output with a newline so the `read` returns 0:

```diff
-    printf '%s\t%s' "${PR_STATUS_OPTION_ID}" "${PR_STATUS_NAME}"
+    printf '%s\t%s\n' "${PR_STATUS_OPTION_ID}" "${PR_STATUS_NAME}"
```
(same for the `issue_status` branch).

## Verification

- New bats test drives the `read` directly and asserts it succeeds; it **fails against the pre-fix script** (confirmed by reverting the `printf` in a temp copy → `not ok`).
- `shellcheck`, `shfmt -i 2`, and the full bats suite (9 tests) pass.
- `desired_status`'s existing tests are unaffected — bats `run`/`$output` strips trailing newlines.

This is a follow-up to the now-merged #130 (tracing), opened as a fresh PR per the repo's contribution flow. Left as a draft for you to review and merge; the next scheduled run after merge should go green and actually reconcile the board.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pvb3RWiRH2Aiuf6k1SWy7w)_