### PR TITLE
Prompt for Cloudflare master token in bootstrap

### DIFF
--- a/docs/how-to/create-master-cloudflare-token.md
+++ b/docs/how-to/create-master-cloudflare-token.md
@@ -12,7 +12,9 @@ deployer Cloudflare tokens. Operator-only — never enters CI.
    - `Zone > Zone — Read`, `DNS — Read`, `Zone Settings — Read` on
      `alunduil.com` (read is enough; the token only references the
      zone)
-2. Export as `CLOUDFLARE_API_TOKEN` before bootstrap apply.
+2. Supply it to the bootstrap apply: either `export
+   TF_VAR_cloudflare_master_token=...`, or paste it when `just
+   bootstrap` prompts for `cloudflare_master_token`.
 3. Revoke the token in the Cloudflare dashboard once the apply
    succeeds. Cloudflare only shows the value at creation time, so any
    future bootstrap apply needs a freshly created master token.

--- a/terraform/bootstrap/cloudflare_tokens.tf
+++ b/terraform/bootstrap/cloudflare_tokens.tf
@@ -2,27 +2,27 @@
 # SPDX-License-Identifier: MIT
 
 data "cloudflare_api_token_permission_groups_list" "zone_read" {
-  name  = "Zone%20Read"
+  name  = "Zone Read"
   scope = "com.cloudflare.api.account.zone"
 }
 
 data "cloudflare_api_token_permission_groups_list" "dns_read" {
-  name  = "DNS%20Read"
+  name  = "DNS Read"
   scope = "com.cloudflare.api.account.zone"
 }
 
 data "cloudflare_api_token_permission_groups_list" "dns_write" {
-  name  = "DNS%20Write"
+  name  = "DNS Write"
   scope = "com.cloudflare.api.account.zone"
 }
 
 data "cloudflare_api_token_permission_groups_list" "zone_settings_read" {
-  name  = "Zone%20Settings%20Read"
+  name  = "Zone Settings Read"
   scope = "com.cloudflare.api.account.zone"
 }
 
 data "cloudflare_api_token_permission_groups_list" "zone_settings_write" {
-  name  = "Zone%20Settings%20Write"
+  name  = "Zone Settings Write"
   scope = "com.cloudflare.api.account.zone"
 }
 

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -20,4 +20,6 @@ provider "google" {
   region  = "europe-west1"
 }
 
-provider "cloudflare" {}
+provider "cloudflare" {
+  api_token = var.cloudflare_master_token
+}

--- a/terraform/bootstrap/variables.tf
+++ b/terraform/bootstrap/variables.tf
@@ -10,3 +10,9 @@ variable "billing_account_id" {
     error_message = "Billing account ID must be 18 characters: XXXXXX-XXXXXX-XXXXXX (6 alphanumeric, hyphen, 6 alphanumeric, hyphen, 6 alphanumeric)"
   }
 }
+
+variable "cloudflare_master_token" {
+  type        = string
+  sensitive   = true
+  description = "Master Cloudflare token: User > API Tokens — Write plus Zone/DNS/Zone-Settings Read on alunduil.com. Create at https://dash.cloudflare.com/profile/api-tokens and revoke after apply. Full steps: docs/how-to/create-master-cloudflare-token.md"
+}


### PR DESCRIPTION
## Summary

`just bootstrap` now asks for the Cloudflare master token at the apply
prompt — with the dashboard link and required scopes inline — instead
of silently reading `CLOUDFLARE_API_TOKEN` and failing late with an
opaque `403` on the `/user/tokens/permission_groups` lookups when the
wrong (e.g. everyday DNS-scoped) token is exported.

Also fixes the permission-group `name` filters, which were
pre-URL-encoded (`"Zone%20Read"`); the v5 provider encoded them again
to `"Zone%2520Read"`, so the lookups matched nothing and `result[0]`
would fail even with a valid token. This bug has been latent since the
filters were introduced — bootstrap has never been exercised through a
real apply on this path.

## Gotchas

- The variable is named `cloudflare_master_token`, **not**
  `cloudflare_api_token`, on purpose: the `alunduil` layer takes
  `TF_VAR_cloudflare_api_token` (the everyday DNS token). Sharing the
  name would let that token silently satisfy bootstrap and reintroduce
  the exact 403 this change fixes. The distinct name guarantees the
  prompt fires.
- Terraform's interactive prompt does not mask input, even for
  `sensitive` vars, so the pasted token is visible on screen. Accepted
  here because the master token is created → used → revoked within one
  apply and never touches CI.

## Verification

- `terraform fmt -check` and `terraform validate` pass in
  `terraform/bootstrap/`.
- Full pre-commit suite passes on the touched files (REUSE,
  terraform_fmt/validate, markdownlint, detect-secrets).
- Not run: a real `terraform apply` against Cloudflare — no creds
  locally, and apply runs post-merge. The `%20` → plain-string fix is
  reasoned from the double-encoded URL in the failing request, not
  confirmed against the live API; the first post-merge apply is the
  real check.