### PR TITLE
Match master-token docs to the Cloudflare dashboard

### DIFF
--- a/docs/how-to/create-master-cloudflare-token.md
+++ b/docs/how-to/create-master-cloudflare-token.md
@@ -6,15 +6,30 @@
 Used once during `terraform/bootstrap/` apply to create the two
 deployer Cloudflare tokens. Operator-only — never enters CI.
 
-1. Create at <https://dash.cloudflare.com/profile/api-tokens> with the
-   following scopes:
-   - `User > API Tokens — Write`
-   - `Zone > Zone — Read`, `DNS — Read`, `Zone Settings — Read` on
-     `alunduil.com` (read is enough; the token only references the
-     zone)
-2. Supply it to the bootstrap apply: either `export
-   TF_VAR_cloudflare_master_token=...`, or paste it when `just
-   bootstrap` prompts for `cloudflare_master_token`.
+1. At <https://dash.cloudflare.com/profile/api-tokens> choose
+   **Create Token** → **Create Custom Token**. Under **Permissions**
+   each row has three dropdowns — the group (defaults to `Account`),
+   the permission, and the access level. Add these rows:
+
+   | Group | Permission    | Access |
+   | ----- | ------------- | ------ |
+   | User  | API Tokens    | Edit   |
+   | Zone  | Zone          | Read   |
+   | Zone  | DNS           | Read   |
+   | Zone  | Zone Settings | Read   |
+
+   Under **Zone Resources** set `Include` → `Specific zone` →
+   `alunduil.com` (read is enough; the token only references the zone).
+2. Supply it to the bootstrap apply by exporting it before running
+   `just bootstrap`:
+
+   ```sh
+   export TF_VAR_cloudflare_master_token=...
+   ```
+
+   Exporting sidesteps Terraform's interactive prompt, which can mangle
+   tokens pasted into terminals with bracketed paste enabled. The
+   prompt still works as a fallback if you skip the export.
 3. Revoke the token in the Cloudflare dashboard once the apply
    succeeds. Cloudflare only shows the value at creation time, so any
    future bootstrap apply needs a freshly created master token.

--- a/terraform/bootstrap/variables.tf
+++ b/terraform/bootstrap/variables.tf
@@ -14,5 +14,20 @@ variable "billing_account_id" {
 variable "cloudflare_master_token" {
   type        = string
   sensitive   = true
-  description = "Master Cloudflare token: User > API Tokens — Write plus Zone/DNS/Zone-Settings Read on alunduil.com. Create at https://dash.cloudflare.com/profile/api-tokens and revoke after apply. Full steps: docs/how-to/create-master-cloudflare-token.md"
+  description = <<-EOT
+    Master Cloudflare token, created by hand and revoked after apply.
+
+    At https://dash.cloudflare.com/profile/api-tokens choose
+    Create Custom Token. Each Permissions row has three dropdowns —
+    group (defaults to Account), permission, access. Add these rows:
+
+      User | API Tokens    | Edit
+      Zone | Zone          | Read
+      Zone | DNS           | Read
+      Zone | Zone Settings | Read
+
+    Set Zone Resources to: Include | Specific zone | alunduil.com.
+
+    Full steps: docs/how-to/create-master-cloudflare-token.md
+  EOT
 }


### PR DESCRIPTION
## Summary

The bootstrap prompt and the create-master-token how-to now mirror the
Cloudflare **Create Custom Token** form, so the scopes can be followed
while clicking through it. Previously both used the API's vocabulary
("Write") and a structure with no counterpart in the dashboard — there
is no "Write" access level to pick, only "Edit" — so the guidance broke
exactly where it's needed. Follow-up to #156.

## Gotchas

- Documentation only — no Terraform resource or permission-group change.
  The granted scopes are identical to #156 (API Tokens edit; Zone/DNS/
  Zone-Settings read on `alunduil.com`); only the words describing them
  changed to match the GUI.
- The variable description is now a `<<-EOT` heredoc so it renders as a
  readable block at the interactive prompt rather than one long line.

## Verification

- `terraform fmt -check` and `terraform validate` pass in
  `terraform/bootstrap/`.
- Pre-commit ran on commit (markdownlint, REUSE, terraform_fmt/validate,
  detect-secrets) — all passed.
- GUI vocabulary ("Edit" access level, group/permission/access per row,
  Zone Resources scoping) confirmed against the operator's live Create
  Custom Token view and Cloudflare's dashboard permissions docs.