### PR TITLE
Add Cloudflare Web Analytics site for blog.alunduil.com

### DIFF
--- a/terraform/alunduil/analytics.tf
+++ b/terraform/alunduil/analytics.tf
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# blog.alunduil.com is gray-clouded (GitHub Pages origin, DNS-only through
+# Cloudflare), so Cloudflare can't inject the beacon snippet. auto_install
+# stays off; the blog hand-injects the beacon from its source using the
+# site_token exposed via output.blog_web_analytics_token.
+resource "cloudflare_web_analytics_site" "blog_alunduil_com" {
+  account_id   = cloudflare_zone.alunduil_com.account.id
+  host         = "blog.alunduil.com"
+  auto_install = false
+}

--- a/terraform/alunduil/outputs.tf
+++ b/terraform/alunduil/outputs.tf
@@ -11,3 +11,9 @@ output "alunduil_com_ds" {
   }
   description = "DS record fields to publish at the Squarespace registrar for alunduil.com"
 }
+
+# Public beacon token (shipped in the blog's client-side JS), not a secret.
+output "blog_web_analytics_token" {
+  value       = cloudflare_web_analytics_site.blog_alunduil_com.site_token
+  description = "Web Analytics beacon token for blog.alunduil.com (paste into blog.alunduil.com src/config.ts cloudflareWebAnalyticsToken)"
+}


### PR DESCRIPTION
## Summary

blog.alunduil.com's Web Analytics beacon token is now produced by Terraform instead of a dashboard click, keeping the Cloudflare-managed-by-Terraform posture from #37. Lands `cloudflare_web_analytics_site.blog_alunduil_com` in a new `analytics.tf` and exposes the token via the `blog_web_analytics_token` output.

Closes #53

## Gotchas

- `auto_install = false` is deliberate: the blog is gray-clouded (GitHub Pages origin, DNS-only through Cloudflare), so Cloudflare can't inject the snippet — the blog hand-injects the beacon. `host` is set instead of `zone_tag`.
- New `analytics.tf` rather than appending to `dns.tf`, keeping the repo's by-concern file split. Grouping all blog resources into a module was considered and rejected for now — it'd be a singleton and would drag out-of-scope state moves into this PR.
- The output isn't marked `sensitive`: the beacon token ships in the blog's client-side JS, so it's public, not a secret.

## Handoff to the blog.alunduil.com side

The consumer is alunduil/blog.alunduil.com#149 (open draft), which reads the token from repo config. The token is generated by Cloudflare, so it only exists after this is applied. For that session:

```sh
cd terraform/alunduil && terraform output -raw blog_web_analytics_token
```

Paste the value into blog.alunduil.com's config and commit — the commit triggers the `pages.yml` deploy, so the beacon goes live without a manual rebuild. The value is write-once and effectively immutable (it changes only if the Web Analytics site is recreated), so no ongoing sync is needed. Cross-repo automation (`github_actions_variable` / `github_repository_file`) was considered and rejected: it'd add permanent coupling for a one-time paste, and an Actions Variable would also contradict the blog's existing "commit public build-time values as IaC, not as Actions Variables" convention (see its `PUBLIC_WEBMENTION_IO_USERNAME` in `pages.yml`).

## Verification

- `pre-commit run` on both files passed, incl. `terraform validate` (confirms the `cloudflare_zone.alunduil_com.account.id` reference resolves and the schema is valid) and `terraform fmt`.
- `terraform apply` and dashboard-hit confirmation are deferred to you post-merge per the repo's apply-on-main flow.