### PR TITLE
Audit blog.alunduil.com and harden the GitHub baseline

### DIFF
--- a/terraform/alunduil/repositories.tf
+++ b/terraform/alunduil/repositories.tf
@@ -17,6 +17,9 @@ module "blog_alunduil_com" {
   description  = "Personal blog at blog.alunduil.com"
   homepage_url = "https://blog.alunduil.com"
   topics       = ["blog", "github-pages"]
+  required_status_checks = {
+    contexts = ["build"]
+  }
   pages = {
     cname          = "blog.alunduil.com"
     build_type     = "workflow"

--- a/terraform/modules/github_repository/main.tf
+++ b/terraform/modules/github_repository/main.tf
@@ -44,6 +44,14 @@ resource "github_branch_protection" "this" {
 
   allows_deletions    = false
   allows_force_pushes = false
+
+  dynamic "required_status_checks" {
+    for_each = var.required_status_checks != null ? [var.required_status_checks] : []
+    content {
+      strict   = required_status_checks.value.strict
+      contexts = required_status_checks.value.contexts
+    }
+  }
 }
 
 resource "github_repository_vulnerability_alerts" "this" {

--- a/terraform/modules/github_repository/main.tf
+++ b/terraform/modules/github_repository/main.tf
@@ -23,6 +23,15 @@ resource "github_repository" "this" {
   delete_branch_on_merge      = true
   archive_on_destroy          = true
 
+  security_and_analysis {
+    secret_scanning {
+      status = "enabled"
+    }
+    secret_scanning_push_protection {
+      status = "enabled"
+    }
+  }
+
   dynamic "template" {
     for_each = var.template != null ? [var.template] : []
     content {

--- a/terraform/modules/github_repository/variables.tf
+++ b/terraform/modules/github_repository/variables.tf
@@ -37,6 +37,21 @@ variable "default_branch" {
   EOT
 }
 
+variable "required_status_checks" {
+  type = object({
+    contexts = list(string)
+    strict   = optional(bool, true)
+  })
+  default     = null
+  description = <<-EOT
+    Status checks that must pass before merging into the default branch.
+    contexts are matched by check-run name; strict requires the branch to
+    be up to date first. Omit to leave the branch ungated (the baseline
+    for most repos). Only require check names that are unique on a PR —
+    a name shared by several workflows can't be pinned to one of them.
+  EOT
+}
+
 variable "has_discussions" {
   type        = bool
   default     = false


### PR DESCRIPTION
## Summary

Auditing `blog.alunduil.com` against the baseline (the #27 review) surfaced two settings worth fixing in Terraform, plus live cruft cleaned up out-of-band.

- **Gate `main` on the Astro `build` check.** Adds an optional `required_status_checks` knob to the `github_repository` module (defaults to `null`, so every other repo stays ungated) and requires `build`, strict — a PR that breaks the published site can no longer merge.
- **Enable secret scanning + push protection in the shared module.** Both were off on blog; both are free on public repos with no workflow dependency, so they go in the baseline for all 11 managed repos.

Closes #27

## Gotchas

- **`build` is the only requireable check.** `bats`, `lychee`, and `pre-commit` each name their job `run`, collapsing to one ambiguous context classic branch protection can't pin. Requiring those needs an upstream job rename first (worth a blog.alunduil.com issue).
- **`security_and_analysis` on public repos** can show provider drift in some versions — watch the first apply. No `advanced_security` block (implicitly on for public; setting it errors).
- **Two hardening knobs were deliberately left out of the baseline:** `default_workflow_permissions = "read"` and `sha_pinning_required = true`. A SHA-pin scan found `zfs-replicate` (14) and `woodland-generators` (1) still tag-pin actions, so uniform enforcement would block their workflows; token-read needs a per-repo audit of permission declarations. Apply runs out of band, so silent breakage is the risk. Tracked for a follow-up once those repos are SHA-pinned.

## Done out-of-band on blog.alunduil.com (not Terraform)

- Deleted the stale 2017 `master` branch carrying the dead `continuous-integration/travis-ci` required check (history preserved via tags `1.0.0`–`1.0.4`).
- Removed 3 write collaborators (velveteer, swarren83, perniferuse) and 5 dead webhooks (Cloud Source ×2, Travis, Twist, libraries.io).
- Enabled private vulnerability reporting (no provider resource exists for it — manual baseline item).

## Verification

- `terraform validate` passes on `terraform/alunduil`; `fmt -check` and full pre-commit clean.
- Provider schema (`required_status_checks` contexts/strict, `security_and_analysis` blocks) confirmed against `integrations/github` v6.12.1 docs.
- Confirmed `pages.yml` declares its own `permissions:`, and scanned all 11 repos' workflow action pins to quantify the deferred-knob risk.