### PR TITLE
Import pre-existing default-branch rulesets

### DIFF
--- a/terraform/alunduil/repositories.tf
+++ b/terraform/alunduil/repositories.tf
@@ -87,3 +87,22 @@ module "zfs_replicate" {
   topics         = ["zfs", "replication", "snapshots"]
   default_branch = "master"
 }
+
+# These three repos already had a hand-created ruleset named "default" before
+# the baseline module introduced one, so the first apply hit GitHub's
+# "Name must be unique" (422) instead of creating. Adopt the existing rulesets
+# into state so apply reconciles them. Remove once applied.
+import {
+  to = module.alunduil_chezmoi.github_repository_ruleset.default_branch
+  id = "alunduil-chezmoi:15615310"
+}
+
+import {
+  to = module.alunduil_infrastructure.github_repository_ruleset.default_branch
+  id = "alunduil-infrastructure:15541031"
+}
+
+import {
+  to = module.woodland_generators.github_repository_ruleset.default_branch
+  id = "woodland-generators:6845434"
+}


### PR DESCRIPTION
## Summary

The apply on `main` failed after #162 because the baseline module's
`github_repository_ruleset.default_branch` (named `default`) collided with a
hand-created ruleset of the same name on three repos — GitHub returns
`422 Validation Failed ... Name must be unique` when a create would duplicate a
name. These import blocks adopt the existing rulesets into state so the next
apply reconciles them in place instead of trying to create.

The other eight repos had no prior ruleset, so their creates succeeded on the
failed run and are already in state; only these three need importing.

## Gotchas

- `alunduil-chezmoi`'s existing ruleset is currently **disabled** — after
  import the plan will flip it to `active` to match the baseline. Worth
  eyeballing that the reconcile is in-place (update), not a destroy.
- The import blocks are transient. #167 tracks removing them once the adopting
  apply has run.

## Verification

- Confirmed each of the three repos has exactly one `default` ruleset via
  `gh api repos/alunduil/<repo>/rulesets`, captured the IDs used in the import
  blocks (6845434 / 15541031 / 15615310).
- Checked all eleven managed repos; the failing set is exactly these three.
- `pre-commit run --files` passed (terraform fmt + validate, reuse, detect-secrets).