### PR TITLE
Declare zellij-claude-pair repository in baseline

### DIFF
--- a/terraform/alunduil/repositories.tf
+++ b/terraform/alunduil/repositories.tf
@@ -80,13 +80,6 @@ module "woodland_generators" {
   }
 }
 
-module "zellij_conductor" {
-  source      = "../modules/github_repository"
-  name        = "zellij-conductor"
-  description = "Zellij-native plugin that orchestrates Claude Code sessions: projects, tasks, worktrees, and autonomous task chains."
-  topics      = ["zellij", "zellij-plugin", "claude-code", "rust", "wasm", "orchestration"]
-}
-
 module "zellij_claude_pair" {
   source      = "../modules/github_repository"
   name        = "zellij-claude-pair"

--- a/terraform/alunduil/repositories.tf
+++ b/terraform/alunduil/repositories.tf
@@ -80,6 +80,20 @@ module "woodland_generators" {
   }
 }
 
+module "zellij_conductor" {
+  source      = "../modules/github_repository"
+  name        = "zellij-conductor"
+  description = "Zellij-native plugin that orchestrates Claude Code sessions: projects, tasks, worktrees, and autonomous task chains."
+  topics      = ["zellij", "zellij-plugin", "claude-code", "rust", "wasm", "orchestration"]
+}
+
+module "zellij_claude_pair" {
+  source      = "../modules/github_repository"
+  name        = "zellij-claude-pair"
+  description = "Zellij plugin for the Claude Code pairing workflow: in-session repo picker and branch/PR status widgets plus worktree session orchestration."
+  topics      = ["zellij", "zellij-plugin", "claude-code", "rust", "wasm"]
+}
+
 module "zfs_replicate" {
   source         = "../modules/github_repository"
   name           = "zfs-replicate"

--- a/terraform/modules/github_repository/checks.tf
+++ b/terraform/modules/github_repository/checks.tf
@@ -7,7 +7,11 @@ check "default_branch_rename" {
   }
 
   assert {
-    condition     = data.github_repository.current.default_branch == var.default_branch
-    error_message = "Repository ${var.name}: default branch is changing from '${data.github_repository.current.default_branch}' to '${var.default_branch}'. Use GitHub's Rename branch feature (Settings → Branches → Rename) before applying — Terraform won't rename the branch on its own, and only the UI rename preserves PR refs and forks."
+    condition = data.github_repository.current.default_branch == var.default_branch
+    # error_message must reference only plan-time-known values: a newly
+    # created repo's data source resolves unknown, and interpolating the live
+    # default branch here would fail plan with "Invalid template interpolation
+    # value". var.name and var.default_branch are always known.
+    error_message = "Repository ${var.name}: the live default branch differs from the configured '${var.default_branch}'. Use GitHub's Rename branch feature (Settings → Branches → Rename) before applying — Terraform won't rename the branch on its own, and only the UI rename preserves PR refs and forks."
   }
 }


### PR DESCRIPTION
## Summary

Adds the `zellij-claude-pair` GitHub repository to the Terraform baseline so `apply` stands up the home for the consolidated Claude pairing-workflow plugin (#155) — one Rust → WASM zellij plugin owning the whole pairing surface (in-session repo picker, branch/PR status widgets, and the worktree session orchestration #6 originally scoped as a separate project). Also fixes a latent module bug that only surfaces when the module *creates* a repo rather than managing an existing one.

## Gotchas

- **Scope decision, not just a config line.** #6 scoped orchestration as a distinct, claustre-backed mission and #155 deliberately bounded itself away from it ("ship independently"). That boundary only held because orchestration was delegated to claustre. claustre has been abandoned, so orchestration is no longer a separate backend integration — it is just another capability the pair plugin owns. Hence one repo, not two. The follow-up issue work: correct #155's "separate mission" line and close #6 as consolidated (the move that folded #54/#26 into #155).
- **Module fix is load-bearing for any new repo.** `github_repository`'s `default_branch_rename` check interpolated the live default branch into its `error_message`. For a repo that doesn't exist yet that value is unknown at plan time, and Terraform rejects an `error_message` interpolating an unknown ("Invalid template interpolation value"). Every repo the module managed before pre-existed, so `zellij-claude-pair` is the first create to hit it — and so would every future new repo. The assert condition is unchanged; only the message stopped echoing the live value.
- **Repo is created by `apply`, not this PR.** Milestone and bootstrap issues land in `zellij-claude-pair` only once it exists post-apply.
- Inherits the full module baseline (public, squash-only, secret scanning + push protection, default-branch ruleset). No per-repo status checks yet — CI doesn't exist until M0.

## Verification

- First CI run failed plan with exactly the unknown-interpolation error on the check's `error_message`; the fix removes that interpolation. Re-verified by CI's Terraform Plan on the pushed fix (local plan needs GitHub credentials, run out-of-band).
- `terraform validate` + pre-commit `terraform_fmt`/`terraform_validate` pass on both commits.

Refs #155, #6