### PR TITLE
Add hackage release environment for collection-json.hs

### DIFF
--- a/terraform/alunduil/repositories.tf
+++ b/terraform/alunduil/repositories.tf
@@ -32,8 +32,7 @@ module "collection_json_hs" {
   name        = "collection-json.hs"
   description = "Collection+JSON Tools for Haskell"
   topics      = ["haskell-library", "collection-json", "haskell", "hypermedia"]
-  # Scopes HACKAGE_TOKEN and gives the tag-driven release workflow a
-  # publish target. No deploy gate: PR review already gates the change.
+  # Deployment environment for Hackage releases.
   environments = ["hackage"]
 }
 

--- a/terraform/alunduil/repositories.tf
+++ b/terraform/alunduil/repositories.tf
@@ -32,11 +32,9 @@ module "collection_json_hs" {
   name        = "collection-json.hs"
   description = "Collection+JSON Tools for Haskell"
   topics      = ["haskell-library", "collection-json", "haskell", "hypermedia"]
-  environments = {
-    # Scopes HACKAGE_TOKEN and gives the tag-driven release workflow a
-    # publish target. No reviewers: PR review already gates the change.
-    hackage = {}
-  }
+  # Scopes HACKAGE_TOKEN and gives the tag-driven release workflow a
+  # publish target. No deploy gate: PR review already gates the change.
+  environments = ["hackage"]
 }
 
 module "grafana" {

--- a/terraform/alunduil/repositories.tf
+++ b/terraform/alunduil/repositories.tf
@@ -32,6 +32,11 @@ module "collection_json_hs" {
   name        = "collection-json.hs"
   description = "Collection+JSON Tools for Haskell"
   topics      = ["haskell-library", "collection-json", "haskell", "hypermedia"]
+  environments = {
+    # Scopes HACKAGE_TOKEN and gives the tag-driven release workflow a
+    # publish target. No reviewers: PR review already gates the change.
+    hackage = {}
+  }
 }
 
 module "grafana" {

--- a/terraform/modules/github_repository/main.tf
+++ b/terraform/modules/github_repository/main.tf
@@ -108,24 +108,11 @@ resource "github_repository_vulnerability_alerts" "this" {
   repository = github_repository.this.name
 }
 
-data "github_user" "reviewer" {
-  for_each = toset(flatten([for env in var.environments : env.reviewers]))
-  username = each.value
-}
-
 resource "github_repository_environment" "this" {
   for_each = var.environments
 
   repository  = github_repository.this.name
-  environment = each.key
-  wait_timer  = each.value.wait_timer
-
-  dynamic "reviewers" {
-    for_each = length(each.value.reviewers) > 0 ? [each.value.reviewers] : []
-    content {
-      users = [for username in reviewers.value : data.github_user.reviewer[username].id]
-    }
-  }
+  environment = each.value
 }
 
 resource "github_repository_pages" "this" {

--- a/terraform/modules/github_repository/main.tf
+++ b/terraform/modules/github_repository/main.tf
@@ -108,6 +108,26 @@ resource "github_repository_vulnerability_alerts" "this" {
   repository = github_repository.this.name
 }
 
+data "github_user" "reviewer" {
+  for_each = toset(flatten([for env in var.environments : env.reviewers]))
+  username = each.value
+}
+
+resource "github_repository_environment" "this" {
+  for_each = var.environments
+
+  repository  = github_repository.this.name
+  environment = each.key
+  wait_timer  = each.value.wait_timer
+
+  dynamic "reviewers" {
+    for_each = length(each.value.reviewers) > 0 ? [each.value.reviewers] : []
+    content {
+      users = [for username in reviewers.value : data.github_user.reviewer[username].id]
+    }
+  }
+}
+
 resource "github_repository_pages" "this" {
   count = var.pages != null ? 1 : 0
 

--- a/terraform/modules/github_repository/variables.tf
+++ b/terraform/modules/github_repository/variables.tf
@@ -69,19 +69,13 @@ variable "template" {
 }
 
 variable "environments" {
-  type = map(object({
-    reviewers  = optional(list(string), [])
-    wait_timer = optional(number, 0)
-  }))
-  default     = {}
+  type        = set(string)
+  default     = []
   description = <<-EOT
-    Deployment environments keyed by name. An environment scopes its own
-    secrets (e.g. a Hackage upload token) and gives a release workflow a
-    target to declare via `environment: <name>`. reviewers (GitHub
-    usernames, resolved to user IDs) impose a deploy-time approval gate;
-    leave it empty when branch protection already gates the change and a
-    second gate would only add friction. wait_timer delays the job by the
-    given number of minutes after it is triggered.
+    Deployment environment names to create on the repository. An
+    environment scopes its own secrets (e.g. a Hackage upload token) and
+    gives a release workflow a target to declare via `environment: <name>`.
+    Secret values are injected out of band, not by Terraform.
   EOT
 }
 

--- a/terraform/modules/github_repository/variables.tf
+++ b/terraform/modules/github_repository/variables.tf
@@ -68,6 +68,23 @@ variable "template" {
   description = "Template repository to seed this one from. Only meaningful at create time."
 }
 
+variable "environments" {
+  type = map(object({
+    reviewers  = optional(list(string), [])
+    wait_timer = optional(number, 0)
+  }))
+  default     = {}
+  description = <<-EOT
+    Deployment environments keyed by name. An environment scopes its own
+    secrets (e.g. a Hackage upload token) and gives a release workflow a
+    target to declare via `environment: <name>`. reviewers (GitHub
+    usernames, resolved to user IDs) impose a deploy-time approval gate;
+    leave it empty when branch protection already gates the change and a
+    second gate would only add friction. wait_timer delays the job by the
+    given number of minutes after it is triggered.
+  EOT
+}
+
 variable "pages" {
   type = object({
     cname          = optional(string)


### PR DESCRIPTION
## Summary

`collection-json.hs` now has a `hackage` deployment environment, giving
the tag-driven release workflow in alunduil/collection-json.hs#115 a
target to declare via `environment: hackage` and a boundary to scope the
`HACKAGE_TOKEN` upload secret. The `github_repository` module gains an
optional `environments` set so any repo can opt in by name.

Closes #9.

## Gotchas

- **The environment is a bare secret-scoping boundary, by design.** No
  reviewers, no `wait_timer` — branch protection already gates every
  change through PR review, so a deploy-time gate on a tag-triggered
  publish would only add friction. The input is therefore a plain
  `set(string)` of environment names; per-environment config (gates,
  branch policy) gets added back the day a repo actually needs it.
- **Most of #9 was already shipped or is delegated.** Secret scanning +
  push protection landed in #161; the default-branch flip to `main` is
  already satisfied (rename done, module defaults to `main`). The two
  remaining hardening knobs are tracked separately: read-only workflow
  token + SHA-pinning under #165, and the `dependabot_security_updates`
  baseline default under #170. This PR is the last net-new capability
  #9 named.
- **`HACKAGE_TOKEN` is injected out of band, per repo.** Terraform owns
  that the environment *exists*; the secret value goes into the repo's
  `hackage` environment manually (`gh secret set HACKAGE_TOKEN --env
  hackage`). An environment secret is only readable by a job declaring
  `environment: hackage`, which keeps the upload token out of reach of
  CI and PR jobs.

## Verification

- `terraform validate` passed (via pre-commit) with the
  `github_repository_environment` resource.
- `terraform fmt` clean.
- Confirmed against the live repo that collection-json.hs is already on
  `main` (rename #82 closed, `master` gone), so no per-repo
  `default_branch` override is needed.