### PR TITLE
Adopt zellij-claude-pair and colliding rulesets via import

### DIFF
--- a/terraform/alunduil/repositories.tf
+++ b/terraform/alunduil/repositories.tf
@@ -87,6 +87,18 @@ module "zellij_claude_pair" {
   topics      = ["zellij", "zellij-plugin", "claude-code", "rust", "wasm"]
 }
 
+# zellij-claude-pair was created out-of-band with a user token: the CI GitHub
+# App cannot POST /user/repos (403 Resource not accessible by integration), so
+# Terraform adopts the existing repository here rather than creating it. The
+# default branch, ruleset, and vulnerability alerts are created on apply, which
+# the App can do against an existing repo. Remove once applied. The import lives
+# in the root module beside its target because import blocks are not allowed in
+# child modules.
+import {
+  to = module.zellij_claude_pair.github_repository.this
+  id = "zellij-claude-pair"
+}
+
 module "zfs_replicate" {
   source         = "../modules/github_repository"
   name           = "zfs-replicate"
@@ -112,14 +124,4 @@ import {
 import {
   to = module.woodland_generators.github_repository_ruleset.default_branch
   id = "woodland-generators:6845434"
-}
-
-# zellij-claude-pair was created out-of-band with a user token: the CI GitHub
-# App cannot POST /user/repos (403 Resource not accessible by integration), so
-# Terraform adopts the existing repository here rather than creating it. The
-# default branch, ruleset, and vulnerability alerts are created on apply, which
-# the App can do against an existing repo. Remove once applied.
-import {
-  to = module.zellij_claude_pair.github_repository.this
-  id = "zellij-claude-pair"
 }

--- a/terraform/alunduil/repositories.tf
+++ b/terraform/alunduil/repositories.tf
@@ -113,3 +113,13 @@ import {
   to = module.woodland_generators.github_repository_ruleset.default_branch
   id = "woodland-generators:6845434"
 }
+
+# zellij-claude-pair was created out-of-band with a user token: the CI GitHub
+# App cannot POST /user/repos (403 Resource not accessible by integration), so
+# Terraform adopts the existing repository here rather than creating it. The
+# default branch, ruleset, and vulnerability alerts are created on apply, which
+# the App can do against an existing repo. Remove once applied.
+import {
+  to = module.zellij_claude_pair.github_repository.this
+  id = "zellij-claude-pair"
+}


### PR DESCRIPTION
## Summary

Gets `main`'s Terraform Apply green again after #168. The apply failed creating `zellij-claude-pair` because the CI GitHub App can't `POST /user/repos` (403 — App tokens can't create user-account repos; only the org endpoint is open to them). The repo was created out-of-band with a user token, and this PR adds an `import {}` block so apply *adopts* it instead of creating it — then reconciles settings and creates the ruleset, default branch, and vulnerability alerts, all of which the App can do against an existing repo.

Also folds in three ruleset-adoption imports for `alunduil-chezmoi`, `alunduil-infrastructure`, and `woodland-generators`, which carried a hand-made `default` ruleset before the baseline module added one and so hit a 422 "Name must be unique" on apply.

## Gotchas

- **The App-can't-create-user-repos limitation is structural, not a one-off.** Every future new repo under the `alunduil` user needs the same out-of-band create + import. The alternatives (a user PAT in CI, or migrating repos to an org) were weighed and declined to keep the App-only secret posture. Documented here so the next new repo follows the same path.
- **All four imports are transient.** The inline comments say "Remove once applied" — they're no-ops after the adopt apply, and removed in a follow-up to keep the file clean (matching the convention already in this file).
- **Two distinct failures, one file.** The repo import (403 on create) and the ruleset imports (422 on collision) are unrelated root causes that happen to land in `repositories.tf` together; both are "adopt a pre-existing resource so apply reconciles."

## Verification

- Repo exists out-of-band with `main` as default branch (so the default-branch and ruleset resources have a branch to target).
- `terraform validate` + pre-commit `terraform_fmt`/`terraform_validate` pass. The import plan is verified by CI's Terraform Plan (local plan needs credentials, run out-of-band).

Refs #155, #6