### PR TITLE
Stop managing archived network-uri-json repo

### DIFF
--- a/terraform/alunduil/repositories.tf
+++ b/terraform/alunduil/repositories.tf
@@ -55,13 +55,6 @@ module "network_arbitrary" {
   default_branch = "master"
 }
 
-module "network_uri_json" {
-  source      = "../modules/github_repository"
-  name        = "network-uri-json"
-  description = "FromJSON and ToJSON Instances for Network.URI"
-  topics      = ["haskell-library", "haskell", "json", "network-uri", "uri"]
-}
-
 module "siren_json_hs" {
   source      = "../modules/github_repository"
   name        = "siren-json.hs"


### PR DESCRIPTION
## Summary

`network-uri-json` is archived on GitHub. The `integrations/github` provider's `github_repository_vulnerability_alerts` **Read** returns a hard error on every refresh of an archived repo (`repository ... is archived, please remove the resource from your configuration`), independent of configuration. The module creates that resource for every repo, so the archived repo failed the `terraform plan` (`run`) check on every PR — including the unrelated Renovate bump in #182.

This drops `network-uri-json` from the config. Because the module sets `archive_on_destroy = true`, applying the resulting destroy re-archives the repo (PATCH `archived=true`) rather than deleting it. Plan: `0 to add, 0 to change, 4 to destroy`.

## Gotchas

- The repo was temporarily **unarchived** so the provider could refresh it and CI could plan cleanly. It is currently unarchived and stays that way until apply — `archive_on_destroy` re-archives it during `terraform apply`. No direct state surgery (`terraform state rm`) needed.
- Apply deletes the repo's ruleset and vuln-alerts config on GitHub before re-archiving — expected for a dead repo.
- #182 (and any branch cut before this lands) still carries the module block; it needs a rebase onto the updated `main` to clear its `run` check. Renovate will rebase it, or tick its rebase box.

## Verification

- Traced the error to `github_repository_vulnerability_alerts`' Read in the provider source — fires on archived repos regardless of config, which is why config-only fixes alone (with the repo still archived) can't clear the plan.
- Unarchived the repo via `gh`, re-ran the `run` check on this PR: plan succeeds, `0 to add, 0 to change, 4 to destroy`, repo re-archived on destroy. Both checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)