### PR TITLE
Drop home.alunduil.com CNAME for Cloudflare-native DDNS

### DIFF
--- a/terraform/alunduil/dns.tf
+++ b/terraform/alunduil/dns.tf
@@ -3,10 +3,10 @@
 
 # alunduil.com is hosted on Cloudflare. Authoritative NS:
 #   brenna.ns.cloudflare.com, vick.ns.cloudflare.com
-# The zone, a security-relevant subset of zone settings, and all records
-# are Terraform-managed. Settings not declared below track Cloudflare's
-# defaults — add a `cloudflare_zone_setting` resource only when drift
-# detection on a specific one is wanted.
+# The zone, a security-relevant subset of zone settings, and every record
+# except home.alunduil.com are Terraform-managed. Settings not declared
+# below track Cloudflare's defaults — add a `cloudflare_zone_setting`
+# resource only when drift detection on a specific one is wanted.
 
 # Recreating the zone mints a new Cloudflare NS pair, forcing a registrar
 # update and propagation outage. `prevent_destroy` blocks `terraform
@@ -88,14 +88,12 @@ resource "cloudflare_dns_record" "blog_cname" {
   proxied = false
 }
 
-resource "cloudflare_dns_record" "home_cname" {
-  zone_id = cloudflare_zone.alunduil_com.id
-  name    = "home.alunduil.com"
-  type    = "CNAME"
-  content = "alunduil.tplinkdns.com"
-  ttl     = 1
-  proxied = false
-}
+# home.alunduil.com is intentionally absent: a Cloudflare-native DDNS client
+# on TrueNAS owns its A record, writing the dynamic home IP straight into
+# Cloudflare. A Terraform-managed record would fight that client on every
+# plan. plex_cname below still points at it. This replaces a CNAME to
+# alunduil.tplinkdns.com, whose flaky TP-Link nameservers dropped ~25% of
+# queries and tripped UptimeRobot's DNS-resolution checks.
 
 resource "cloudflare_dns_record" "plex_cname" {
   zone_id = cloudflare_zone.alunduil_com.id


### PR DESCRIPTION
## Summary

The Plex UptimeRobot monitors logged five availability incidents over the past week — all with cause `100001` "DNS Resolving problem", each lasting 1–2 minutes. Plex and the TrueNAS host were healthy throughout (container `RUNNING`, CPU ~17%, load <1); UptimeRobot was failing to *resolve* the hostname, not to reach Plex.

Root cause is the resolution chain: `home.alunduil.com` (Cloudflare CNAME) → `alunduil.tplinkdns.com` (TP-Link DDNS) → the home IP. Cloudflare hands the final A record off to TP-Link's nameservers, and `ns1.tplinkdns.com` drops queries — a direct probe lost 2 of 8 (ns2 was clean). UptimeRobot's resolver trips over those drops.

This removes the Terraform-managed CNAME so a Cloudflare-native DDNS client on TrueNAS can own `home.alunduil.com`'s A record instead, writing the dynamic home IP straight into Cloudflare and cutting TP-Link out of the path entirely.

## Gotchas

- **Deliberate coverage gap.** `home.alunduil.com` is now the one record in `dns.tf` not Terraform-managed — the DDNS client owns it out-of-band. Header comment and an inline note flag this so it isn't "fixed" by re-adding a CNAME. `plex.alunduil.com` still CNAMEs to it.
- **Sequencing / brief window.** `terraform apply` deletes the CNAME; the name doesn't exist again until the DDNS container creates the A record (Cloudflare won't hold a CNAME and an A record for the same name simultaneously). Deploy the container right after the apply. Plex clients cache the old IP for 900s (record TTL) so real impact is minimal.
- **Token lives outside IaC.** The DDNS client uses a hand-created Cloudflare token scoped to DNS:Edit + Zone:Read on the zone — a deliberate divergence from the Terraform-managed deployer tokens, keeping a long-running host daemon off the CI token.

## Verification

- `terraform fmt -check` and `terraform validate`: pass.
- Full pre-commit suite (REUSE, terraform_fmt/validate, detect-secrets, …): pass.
- DNS chain and TP-Link nameserver packet loss reproduced live via `dig` against `ns1`/`ns2.tplinkdns.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)