### PR TITLE
Archive murl by removing it from Terraform

### DIFF
--- a/terraform/alunduil/repositories.tf
+++ b/terraform/alunduil/repositories.tf
@@ -41,13 +41,6 @@ module "grafana" {
   name   = "grafana"
 }
 
-module "murl" {
-  source         = "../modules/github_repository"
-  name           = "murl"
-  description    = "Small Toy URL Shortener in Haskell"
-  default_branch = "master"
-}
-
 module "network_arbitrary" {
   source         = "../modules/github_repository"
   name           = "network-arbitrary"


### PR DESCRIPTION
## Summary

Archives the `murl` repo (a dormant Haskell toy project). The `github_repository`
module sets `archive_on_destroy = true`, so removing the module block archives the
repo on apply rather than deleting it.

## Gotchas

- Archiving on GitHub directly would break the `terraform-plan` check on *every*
  PR: the in-state `github_repository_vulnerability_alerts` Read errors against an
  archived repo. Letting the destroy do the archiving (repo still active at plan
  time) avoids that.
- The destroy deletes murl's ruleset and vuln-alerts config on GitHub before
  archiving — expected for a mothballed repo.

## Verification

- Confirmed murl is currently unarchived on GitHub (`gh api repos/alunduil/murl`),
  so the plan refresh won't hit the archived-repo Read error.
- Review the `terraform-plan` CI comment to confirm the repo is **archived, not
  destroyed**.

Closes #20