### PR TITLE
Isolate bootstrap state in its own GCS bucket

### DIFF
--- a/scripts/bootstrap-terraform-state.sh
+++ b/scripts/bootstrap-terraform-state.sh
@@ -4,23 +4,29 @@
 set -euo pipefail
 set -x
 
-BUCKET_NAME="${BUCKET_NAME:-alunduil-tfstate}"
 PROJECT_ID="${PROJECT_ID:-alunduil}"
 LOCATION="${LOCATION:-EU}"
 
-# Create bucket if it doesn't exist
-if gcloud storage buckets describe "gs://${BUCKET_NAME}" --project "${PROJECT_ID}" >/dev/null 2>&1; then
-  echo "Bucket gs://${BUCKET_NAME} already exists in project ${PROJECT_ID}."
-else
-  gcloud storage buckets create "gs://${BUCKET_NAME}" \
-    --project "${PROJECT_ID}" \
-    --location "${LOCATION}" \
-    --public-access-prevention \
-    --uniform-bucket-level-access
-fi
+# terraform/alunduil/ and terraform/bootstrap/ keep their state in separate
+# buckets: the CI deployer SAs hold bucket-wide IAM on the alunduil/ bucket, so
+# a shared bucket would let the plan workflow read bootstrap state (which holds
+# the Cloudflare deployer tokens in plaintext).
+BUCKETS=(alunduil-tfstate alunduil-bootstrap-tfstate)
 
-# Ensure versioning is enabled for state protection
-gcloud storage buckets update "gs://${BUCKET_NAME}" \
-  --project "${PROJECT_ID}" \
-  --uniform-bucket-level-access \
-  --versioning
+for bucket in "${BUCKETS[@]}"; do
+  if gcloud storage buckets describe "gs://${bucket}" --project "${PROJECT_ID}" >/dev/null 2>&1; then
+    echo "Bucket gs://${bucket} already exists in project ${PROJECT_ID}."
+  else
+    gcloud storage buckets create "gs://${bucket}" \
+      --project "${PROJECT_ID}" \
+      --location "${LOCATION}" \
+      --public-access-prevention \
+      --uniform-bucket-level-access
+  fi
+
+  # Ensure versioning is enabled for state protection
+  gcloud storage buckets update "gs://${bucket}" \
+    --project "${PROJECT_ID}" \
+    --uniform-bucket-level-access \
+    --versioning
+done

--- a/terraform/bootstrap/backend.tf
+++ b/terraform/bootstrap/backend.tf
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 
-# State lives in the same bucket as terraform/alunduil/ under a separate prefix.
+# Dedicated bucket, separate from terraform/alunduil/, so the CI deployer SAs —
+# which hold bucket-wide IAM on alunduil-tfstate — can't read bootstrap state.
 # The bucket is created out-of-band by scripts/bootstrap-terraform-state.sh.
 terraform {
   backend "gcs" {
-    bucket = "alunduil-tfstate"
+    bucket = "alunduil-bootstrap-tfstate"
     prefix = "bootstrap"
   }
 }

--- a/terraform/bootstrap/state_bucket.tf
+++ b/terraform/bootstrap/state_bucket.tf
@@ -1,8 +1,9 @@
 # SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
 # SPDX-License-Identifier: MIT
 
-# Not TF-managed: bootstrap stores its state in this bucket, so managing the
-# bucket here would chicken-and-egg.
+# Backs terraform/alunduil/ state. Referenced here only to attach deployer-SA
+# IAM; created out-of-band by scripts/bootstrap-terraform-state.sh, so it stays
+# a data source rather than a managed resource.
 data "google_storage_bucket" "state" {
   name = "alunduil-tfstate"
 }


### PR DESCRIPTION
## Summary

`terraform/bootstrap/` and `terraform/alunduil/` share `alunduil-tfstate`, and the CI deployer SAs hold bucket-wide `objectViewer`/`objectAdmin` on it — so the plan workflow (every PR, Renovate included) can read bootstrap state, which stores the Cloudflare deployer tokens in plaintext. Splitting bootstrap onto its own `alunduil-bootstrap-tfstate` bucket that no CI principal has IAM on closes that read path structurally, the last leg of the #77 / PR #79 threat model.

The bootstrap script now provisions both buckets; `backend.tf` points at the new one; the shared bucket stays as the `terraform/alunduil/` backend only.

Closes #80

## Gotchas

- **This PR is only the repo half — the state migration is a manual runbook, not applied by CI.** Bootstrap applies locally with ADC, and moving live state can't happen in a plan. Once merged, run (ADC authenticated):
  ```sh
  scripts/bootstrap-terraform-state.sh   # creates alunduil-bootstrap-tfstate
  terraform -chdir=terraform/bootstrap init -migrate-state
  ```
  `just bootstrap`'s plain `init` won't relocate existing state — the one-time `-migrate-state` is required.
- After migrating, purge the old copies so they aren't readable via the shared bucket:
  ```sh
  gcloud storage rm --recursive gs://alunduil-tfstate/bootstrap/
  # plus noncurrent versions:
  gcloud storage rm --all-versions --recursive gs://alunduil-tfstate/bootstrap/
  ```
- Kept `prefix = "bootstrap"` on the new backend rather than dropping it — makes `-migrate-state` a pure bucket swap with the state object at the same path, nothing else moving.
- No IAM resource is added for the new bucket, and that's intentional — the acceptance criterion is that the deployer SAs get *nothing* there.

## Verification

- `terraform fmt`, `terraform validate`, `shellcheck`, `shfmt`, and `reuse lint` pass via pre-commit on all three changed files.
- Not yet run against live state — the `plan` no-op, `get-iam-policy` check, and `gsutil cat` permission-denied checks from the acceptance criteria depend on the migration runbook above, which is post-merge and out-of-band.