### PR TITLE
Add scaffold-repo skill for new-repo module blocks

### DIFF
--- a/.claude/skills/scaffold-repo/SKILL.md
+++ b/.claude/skills/scaffold-repo/SKILL.md
@@ -1,85 +1,118 @@
 ---
 name: scaffold-repo
-description: Scaffold a new GitHub repository for the alunduil org as a Terraform github_repository module block. Reads the module and every repositories.tf, classifies each input as shared (inherit the default), archetype-shared (matches a cluster like Haskell library or static site), or specific (ask), emits a draft module block setting only the non-default values, and lists the steps Terraform can't do. Use when adding a repo to terraform/*/repositories.tf.
+description: Scaffold a new GitHub repository for the alunduil org end to end. Classifies each github_repository module input as shared/archetype-shared/specific against the module and the existing repositories.tf, creates the repo (confirmed, via gh) so Terraform can adopt it, emits the module block plus the adoption import in one draft PR, and files a follow-up to remove the import after apply. Use when adding a repo to terraform/*/repositories.tf.
 ---
 
 # Scaffold a new repository
 
-Produce a draft `module ""` block for `terraform/<stack>/repositories.tf`
-plus a checklist of steps Terraform can't perform. The `github_repository`
-module and the `repositories.tf` files are the source of truth for the
-shared-vs-specific split — derive it from them every run, don't trust a
+Drive a new repo from name + intent to a draft PR that CI can apply
+cleanly: classify the module inputs, create the repo (confirmed) so
+Terraform can adopt it, and land the adoption `import` in the same PR. The
+`github_repository` module and the `repositories.tf` files are the source
+of truth for the shared-vs-specific split — derive it every run, not from a
 snapshot.
 
-Out of scope (never do these):
-
-- `terraform apply` — CI applies on merge.
-- Creating the repo through the GitHub API as a side effect. The skill
-  emits Terraform. (The repo must still exist before apply can adopt it;
-  the operator creates it out-of-band — see the checklist.)
+Never run `terraform apply`/`plan` locally — CI applies on merge and posts
+the plan on the PR. Repo creation goes through `gh` under the operator's
+token as a confirmed step (the CI GitHub App can't create user repos); it
+is never silent and never uses the Terraform GitHub provider to side-effect
+the repo into existence.
 
 ## Gather
 
-- Repo name (the GitHub slug).
+- Repo name — help pick one when the intent is firmer than the name.
 - Intent: language / archetype, release flow, GitHub Pages, discussions,
-  template seed, whether the repo already exists and on what branch.
+  template seed. Whether the repo already exists, and on what default
+  branch.
 
-## Method
+## Classify (source of truth = the code)
 
-1. Read `terraform/modules/github_repository/variables.tf` for the current
-   input list and defaults, and `main.tf` for the settings hardcoded on
-   every repo (public visibility, squash-only merges, secret scanning, the
-   default ruleset, vulnerability alerts). Those hardcoded ones are not
-   inputs — never restate them in a module block.
+1. Read `modules/github_repository/variables.tf` (inputs + defaults) and
+   `main.tf` (settings hardcoded on every repo — public visibility,
+   squash-only merges, secret scanning, the default ruleset, vulnerability
+   alerts). Those hardcoded ones are not inputs; never restate them.
 2. Read every `terraform/*/repositories.tf` and tally each input's value
    distribution across the module blocks.
 3. Classify each input for the new repo:
-   - **Shared** — the module default matches nearly every repo. Leave it
-     unset so the block inherits it silently.
-   - **Archetype-shared** — set across the cluster the new repo joins.
-     Match the cluster (below), then copy its value.
-   - **Specific** — varies per repo. Ask. (`description`, `topics`,
-     `homepage_url` are always specific.)
-4. Archetype clusters currently present — re-derive the actual values from
-   the members, this list is a starting hint not an inventory:
-   - Haskell library (`*.hs` name or `haskell-library` topic): shared
-     topics (haskell / haskell-library / hypermedia); published ones set
-     `environments = ["hackage"]`; older ones predate the `main`
-     convention (`default_branch = "master"`).
-   - Static site / GitHub Pages: `pages` block + `homepage_url` + a build
-     status check; `github-pages` topic.
-   - Rust/WASM plugin, CLI tool: topic conventions only so far.
-5. Emit the block. Module label = repo name with dots and dashes turned
-   into underscores (match existing blocks). Set only archetype-shared and
-   specific values, in the module's declaration order. `terraform_fmt`
-   aligns the `=`; leave that to pre-commit.
+   - **Shared** — matches the module default; leave it unset.
+   - **Archetype-shared** — set across the cluster the repo joins; copy
+     the cluster's value.
+   - **Specific** — varies per repo; ask (`description`, `topics`,
+     `homepage_url`).
+4. Archetype clusters — re-derive values from the members, this is a hint
+   not an inventory:
+   - Haskell library (`*.hs` name or `haskell-library` topic): haskell /
+     hypermedia topics; published ones set `environments = ["hackage"]`;
+     older ones predate `main` (`default_branch = "master"`).
+   - Static site / Pages: `pages` block + `homepage_url` + a build status
+     check; `github-pages` topic.
+   - Rust/WASM plugin, CLI: topic conventions only so far.
+5. Draft `module "<name_underscored>"` (dots and dashes → underscores)
+   setting only archetype-shared and specific values, in the module's
+   declaration order. Leave `=` alignment to `terraform_fmt`.
 
-## Out-of-Terraform checklist (include whichever apply)
+## Path A — net-new repo (you're inventing it)
 
-- **The repo must exist before apply.** The CI GitHub App can't
-  `POST /user/repos` (403). The operator creates it out-of-band
-  (`gh repo create`); then add a root `import` block adopting
-  `module.<name>.github_repository.this` beside the module — import blocks
-  aren't allowed in child modules (see the zellij-claude-pair precedent).
-  Remove the import once applied.
-- **A hand-created "default" ruleset** makes the first apply hit 422
-  "Name must be unique". Add an import for
-  `module.<name>.github_repository_ruleset.default_branch` with id
-  `<repo>:<ruleset_id>`. Remove once applied.
-- **Adopting an existing repo on `master`**: set
-  `default_branch = "master"`, or rename via GitHub's UI
-  (Settings → Branches → Rename) first. The module's `check` block fails
-  the plan when the live default branch differs from the configured one.
-- **SPDX/REUSE headers** on new files. `.tf` files take inline headers;
-  `REUSE.toml` already covers `.claude/**`, JSON, and lock files.
-- **Environment secrets** (e.g. the Hackage token for
-  `environments = ["hackage"]`) are injected out of band, not by
-  Terraform.
-- **Pages**: `https_enforced` can only be set `true` after GitHub issues
-  the Let's Encrypt cert — tick "Enforce HTTPS" in the UI first. The apex
-  CNAME lives in Cloudflare DNS, not Cloud DNS; add it there.
+1. Create the repo as a confirmed step (external state — show the command
+   and pause before running):
+
+   ```bash
+   gh repo create alunduil/<name> --public --add-readme --description "<desc>"
+   ```
+
+   `--add-readme` is required: it seeds an initial commit on `main` so
+   `github_branch_default` has a branch to point at. Against an empty repo,
+   apply fails when it tries to set the default branch.
+2. Add the module block **and** its adoption import beside it — import
+   blocks are illegal in child modules, so they live in `repositories.tf`:
+
+   ```hcl
+   import {
+     to = module.<name>.github_repository.this
+     id = "<name>"
+   }
+   ```
+
+   Import only the repository resource. A fresh repo has no `default`
+   ruleset, so the module creates it — do **not** import the ruleset here.
+3. pre-commit, commit, push, draft PR. The body notes the import adopts the
+   repo on first apply and is removed afterward.
+4. File a follow-up issue (use the `issue-create` skill) to remove the
+   import block once apply has landed — it can't be removed until the
+   resource is in state, which happens post-merge. Link it from the PR
+   body.
+
+## Path B — adopt an existing untracked repo
+
+1. No create. Add the module block + the repository import (as in Path A).
+2. If the repo already carries a hand-made `default` ruleset, the first
+   apply hits 422 "Name must be unique" — add its import too, with the id
+   from `gh api repos/alunduil/<name>/rulesets` (the entry named `default`):
+
+   ```hcl
+   import {
+     to = module.<name>.github_repository_ruleset.default_branch
+     id = "<name>:<ruleset_id>"
+   }
+   ```
+
+3. If the live default branch is `master`, set `default_branch = "master"`
+   or rename via GitHub's UI first — the module's `check` block fails the
+   plan on a mismatch.
+4. pre-commit, commit, push, draft PR; follow-up issue to remove the
+   import(s) post-apply.
+
+## Remaining out-of-Terraform notes (include whichever apply)
+
+- SPDX/REUSE headers on new files (`.tf` inline; `REUSE.toml` covers
+  `.claude/**`, JSON, lock files).
+- Environment secrets (e.g. the Hackage token for
+  `environments = ["hackage"]`) are injected out of band, not by Terraform.
+- Pages: `https_enforced` can only be set `true` after GitHub issues the
+  cert — tick "Enforce HTTPS" in the UI first. The apex CNAME lives in
+  Cloudflare DNS, not Cloud DNS; add it there.
 
 ## Finish
 
-Show the module block and the checklist. Don't apply. Open a draft PR only
-if asked, per the repo's contribution flow.
+Show the module block, the create command (Path A), and the checklist.
+Never apply. Open the draft PR per the repo's contribution flow.

--- a/.claude/skills/scaffold-repo/SKILL.md
+++ b/.claude/skills/scaffold-repo/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: scaffold-repo
+description: Scaffold a new GitHub repository for the alunduil org as a Terraform github_repository module block. Reads the module and every repositories.tf, classifies each input as shared (inherit the default), archetype-shared (matches a cluster like Haskell library or static site), or specific (ask), emits a draft module block setting only the non-default values, and lists the steps Terraform can't do. Use when adding a repo to terraform/*/repositories.tf.
+---
+
+# Scaffold a new repository
+
+Produce a draft `module ""` block for `terraform/<stack>/repositories.tf`
+plus a checklist of steps Terraform can't perform. The `github_repository`
+module and the `repositories.tf` files are the source of truth for the
+shared-vs-specific split — derive it from them every run, don't trust a
+snapshot.
+
+Out of scope (never do these):
+
+- `terraform apply` — CI applies on merge.
+- Creating the repo through the GitHub API as a side effect. The skill
+  emits Terraform. (The repo must still exist before apply can adopt it;
+  the operator creates it out-of-band — see the checklist.)
+
+## Gather
+
+- Repo name (the GitHub slug).
+- Intent: language / archetype, release flow, GitHub Pages, discussions,
+  template seed, whether the repo already exists and on what branch.
+
+## Method
+
+1. Read `terraform/modules/github_repository/variables.tf` for the current
+   input list and defaults, and `main.tf` for the settings hardcoded on
+   every repo (public visibility, squash-only merges, secret scanning, the
+   default ruleset, vulnerability alerts). Those hardcoded ones are not
+   inputs — never restate them in a module block.
+2. Read every `terraform/*/repositories.tf` and tally each input's value
+   distribution across the module blocks.
+3. Classify each input for the new repo:
+   - **Shared** — the module default matches nearly every repo. Leave it
+     unset so the block inherits it silently.
+   - **Archetype-shared** — set across the cluster the new repo joins.
+     Match the cluster (below), then copy its value.
+   - **Specific** — varies per repo. Ask. (`description`, `topics`,
+     `homepage_url` are always specific.)
+4. Archetype clusters currently present — re-derive the actual values from
+   the members, this list is a starting hint not an inventory:
+   - Haskell library (`*.hs` name or `haskell-library` topic): shared
+     topics (haskell / haskell-library / hypermedia); published ones set
+     `environments = ["hackage"]`; older ones predate the `main`
+     convention (`default_branch = "master"`).
+   - Static site / GitHub Pages: `pages` block + `homepage_url` + a build
+     status check; `github-pages` topic.
+   - Rust/WASM plugin, CLI tool: topic conventions only so far.
+5. Emit the block. Module label = repo name with dots and dashes turned
+   into underscores (match existing blocks). Set only archetype-shared and
+   specific values, in the module's declaration order. `terraform_fmt`
+   aligns the `=`; leave that to pre-commit.
+
+## Out-of-Terraform checklist (include whichever apply)
+
+- **The repo must exist before apply.** The CI GitHub App can't
+  `POST /user/repos` (403). The operator creates it out-of-band
+  (`gh repo create`); then add a root `import` block adopting
+  `module.<name>.github_repository.this` beside the module — import blocks
+  aren't allowed in child modules (see the zellij-claude-pair precedent).
+  Remove the import once applied.
+- **A hand-created "default" ruleset** makes the first apply hit 422
+  "Name must be unique". Add an import for
+  `module.<name>.github_repository_ruleset.default_branch` with id
+  `<repo>:<ruleset_id>`. Remove once applied.
+- **Adopting an existing repo on `master`**: set
+  `default_branch = "master"`, or rename via GitHub's UI
+  (Settings → Branches → Rename) first. The module's `check` block fails
+  the plan when the live default branch differs from the configured one.
+- **SPDX/REUSE headers** on new files. `.tf` files take inline headers;
+  `REUSE.toml` already covers `.claude/**`, JSON, and lock files.
+- **Environment secrets** (e.g. the Hackage token for
+  `environments = ["hackage"]`) are injected out of band, not by
+  Terraform.
+- **Pages**: `https_enforced` can only be set `true` after GitHub issues
+  the Let's Encrypt cert — tick "Enforce HTTPS" in the UI first. The apex
+  CNAME lives in Cloudflare DNS, not Cloud DNS; add it there.
+
+## Finish
+
+Show the module block and the checklist. Don't apply. Open a draft PR only
+if asked, per the repo's contribution flow.

--- a/.claude/skills/scaffold-repo/SKILL.md
+++ b/.claude/skills/scaffold-repo/SKILL.md
@@ -5,66 +5,63 @@ description: Scaffold a new GitHub repository for the alunduil org end to end. C
 
 # Scaffold a new repository
 
-Drive a new repo from name + intent to a draft PR that CI can apply
-cleanly: classify the module inputs, create the repo (confirmed) so
-Terraform can adopt it, and land the adoption `import` in the same PR. The
+Drive a new repo from name + intent to a draft PR CI can apply cleanly. The
 `github_repository` module and the `repositories.tf` files are the source
-of truth for the shared-vs-specific split — derive it every run, not from a
-snapshot.
+of truth for the shared-vs-specific split — derive it every run, never from
+a snapshot.
 
-Never run `terraform apply`/`plan` locally — CI applies on merge and posts
-the plan on the PR. Repo creation goes through `gh` under the operator's
-token as a confirmed step (the CI GitHub App can't create user repos); it
-is never silent and never uses the Terraform GitHub provider to side-effect
-the repo into existence.
+Two hard rules:
+
+- Never run `terraform apply`/`plan` locally. CI applies on merge and posts
+  the plan on the PR — that comment is the clean/not-clean signal.
+- Create the repo through `gh` under the operator's token, as a confirmed
+  step — never the Terraform provider (the CI App can't create user repos).
 
 ## Gather
 
 - Repo name — help pick one when the intent is firmer than the name.
-- Intent: language / archetype, release flow, GitHub Pages, discussions,
-  template seed. Whether the repo already exists, and on what default
-  branch.
+- Intent: language / archetype, release flow, Pages, discussions, template
+  seed.
+- Does the repo already exist, and on what default branch? Picks the path.
 
-## Classify (source of truth = the code)
+## Classify (the code is the source of truth)
 
-1. Read `modules/github_repository/variables.tf` (inputs + defaults) and
-   `main.tf` (settings hardcoded on every repo — public visibility,
-   squash-only merges, secret scanning, the default ruleset, vulnerability
-   alerts). Those hardcoded ones are not inputs; never restate them.
-2. Read every `terraform/*/repositories.tf` and tally each input's value
-   distribution across the module blocks.
-3. Classify each input for the new repo:
+1. Read `modules/github_repository/variables.tf` for inputs + defaults, and
+   `main.tf` for settings hardcoded on every repo (public visibility,
+   squash-only merges, secret scanning, the default ruleset, vuln alerts).
+   Those aren't inputs — never restate them in a block.
+2. Read every `terraform/*/repositories.tf`; tally each input's values.
+3. Classify each input:
    - **Shared** — matches the module default; leave it unset.
-   - **Archetype-shared** — set across the cluster the repo joins; copy
-     the cluster's value.
+   - **Archetype-shared** — set across the cluster the repo joins; copy its
+     value.
    - **Specific** — varies per repo; ask (`description`, `topics`,
      `homepage_url`).
-4. Archetype clusters — re-derive values from the members, this is a hint
-   not an inventory:
-   - Haskell library (`*.hs` name or `haskell-library` topic): haskell /
-     hypermedia topics; published ones set `environments = ["hackage"]`;
-     older ones predate `main` (`default_branch = "master"`).
-   - Static site / Pages: `pages` block + `homepage_url` + a build status
-     check; `github-pages` topic.
-   - Rust/WASM plugin, CLI: topic conventions only so far.
-5. Draft `module "<name_underscored>"` (dots and dashes → underscores)
-   setting only archetype-shared and specific values, in the module's
-   declaration order. Leave `=` alignment to `terraform_fmt`.
+4. Archetype clusters (re-derive values from the members — hint, not
+   inventory):
+   - Haskell library (`*.hs` / `haskell-library` topic): haskell +
+     hypermedia topics; published → `environments = ["hackage"]`; older →
+     `default_branch = "master"`.
+   - Static site / Pages: `pages` + `homepage_url` + a build check;
+     `github-pages` topic.
+   - Rust/WASM plugin, CLI: topic conventions only.
+5. Draft `module "<name_underscored>"` (dots/dashes → underscores), setting
+   only archetype-shared and specific values in declaration order. Leave
+   `=` alignment to `terraform_fmt`.
 
-## Path A — net-new repo (you're inventing it)
+## Path A — net-new repo
 
-1. Create the repo as a confirmed step (external state — show the command
-   and pause before running):
+1. Confirm, then create (external state — show the command, pause):
 
    ```bash
    gh repo create alunduil/<name> --public --add-readme --description "<desc>"
    ```
 
-   `--add-readme` is required: it seeds an initial commit on `main` so
-   `github_branch_default` has a branch to point at. Against an empty repo,
-   apply fails when it tries to set the default branch.
-2. Add the module block **and** its adoption import beside it — import
-   blocks are illegal in child modules, so they live in `repositories.tf`:
+   `--add-readme` is required: it seeds a commit on `main` so
+   `github_branch_default` has a branch to point at. Empty repo → apply
+   fails setting the default branch.
+2. Add the module block and, beside it, the repository import (import
+   blocks are illegal in child modules):
 
    ```hcl
    import {
@@ -73,21 +70,15 @@ the repo into existence.
    }
    ```
 
-   Import only the repository resource. A fresh repo has no `default`
-   ruleset, so the module creates it — do **not** import the ruleset here.
-3. pre-commit, commit, push, draft PR. The body notes the import adopts the
-   repo on first apply and is removed afterward.
-4. File a follow-up issue (use the `issue-create` skill) to remove the
-   import block once apply has landed — it can't be removed until the
-   resource is in state, which happens post-merge. Link it from the PR
-   body.
+   Repository resource only — a fresh repo has no `default` ruleset, so the
+   module creates it. Don't import the ruleset.
 
 ## Path B — adopt an existing untracked repo
 
-1. No create. Add the module block + the repository import (as in Path A).
-2. If the repo already carries a hand-made `default` ruleset, the first
-   apply hits 422 "Name must be unique" — add its import too, with the id
-   from `gh api repos/alunduil/<name>/rulesets` (the entry named `default`):
+1. Add the module block + repository import (as in Path A, no create).
+2. Repo already has a hand-made `default` ruleset → first apply hits 422
+   "Name must be unique". Import it too, id from
+   `gh api repos/alunduil/<name>/rulesets` (the `default` entry):
 
    ```hcl
    import {
@@ -96,23 +87,24 @@ the repo into existence.
    }
    ```
 
-3. If the live default branch is `master`, set `default_branch = "master"`
-   or rename via GitHub's UI first — the module's `check` block fails the
-   plan on a mismatch.
-4. pre-commit, commit, push, draft PR; follow-up issue to remove the
-   import(s) post-apply.
+3. Live default branch is `master` → set `default_branch = "master"`, or
+   rename via GitHub's UI first (the module's `check` block fails the plan
+   on a mismatch).
 
-## Remaining out-of-Terraform notes (include whichever apply)
+## Land it (both paths)
+
+1. pre-commit → commit → push → draft PR; the body notes the import(s)
+   adopt on first apply and are removed afterward.
+2. File a follow-up issue (`issue-create` skill) to remove the import(s) —
+   they can't go until apply puts the resource in state, post-merge. Link
+   it from the PR body.
+
+## Out-of-Terraform notes (whichever apply)
 
 - SPDX/REUSE headers on new files (`.tf` inline; `REUSE.toml` covers
   `.claude/**`, JSON, lock files).
 - Environment secrets (e.g. the Hackage token for
-  `environments = ["hackage"]`) are injected out of band, not by Terraform.
-- Pages: `https_enforced` can only be set `true` after GitHub issues the
-  cert — tick "Enforce HTTPS" in the UI first. The apex CNAME lives in
-  Cloudflare DNS, not Cloud DNS; add it there.
-
-## Finish
-
-Show the module block, the create command (Path A), and the checklist.
-Never apply. Open the draft PR per the repo's contribution flow.
+  `environments = ["hackage"]`) are injected out of band.
+- Pages: set `https_enforced = true` only after GitHub issues the cert
+  (tick "Enforce HTTPS" in the UI first). The apex CNAME lives in
+  Cloudflare DNS, not Cloud DNS.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,11 @@ check what's already in place:
 - Renovate (`renovate.json`) handles dependency PRs; extend the
   config rather than pinning by hand.
 - Adding a new repo to the org? The `scaffold-repo` skill
-  (`.claude/skills/scaffold-repo/`) drives the module-block workflow:
-  classifies each `github_repository` input as shared/archetype/specific
-  against the existing `repositories.tf` and lists the out-of-Terraform
-  steps.
+  (`.claude/skills/scaffold-repo/`) drives it end to end: classifies each
+  `github_repository` input as shared/archetype/specific against the
+  existing `repositories.tf`, creates the repo via `gh` (confirmed) so
+  Terraform can adopt it, and lands the module block plus the adoption
+  `import` in one draft PR.
 - Credentials: `docs/how-to/bootstrap.md` names the env vars the
   bootstrap needs; the Cloudflare scopes live in
   `docs/how-to/create-master-cloudflare-token.md`. Don't enumerate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,11 @@ check what's already in place:
   back.
 - Renovate (`renovate.json`) handles dependency PRs; extend the
   config rather than pinning by hand.
+- Adding a new repo to the org? The `scaffold-repo` skill
+  (`.claude/skills/scaffold-repo/`) drives the module-block workflow:
+  classifies each `github_repository` input as shared/archetype/specific
+  against the existing `repositories.tf` and lists the out-of-Terraform
+  steps.
 - Credentials: `docs/how-to/bootstrap.md` names the env vars the
   bootstrap needs; the Cloudflare scopes live in
   `docs/how-to/create-master-cloudflare-token.md`. Don't enumerate


### PR DESCRIPTION
## Summary

Adding a repo to the org now runs end to end through the `scaffold-repo`
skill: from a name + rough intent it classifies each `github_repository`
input as shared / archetype-shared / specific against the existing
`repositories.tf`, creates the repo, and lands the Terraform to manage it —
closing the friction that made past additions fail their first apply.

It branches on whether the repo exists yet:

- **Net-new** — `gh repo create --add-readme` (confirmed), then the
  `module` block + repository adoption `import` in one draft PR, plus a
  follow-up issue to remove the import after apply.
- **Adopt-existing** — no create; repository `import`, plus a ruleset
  `import` when a pre-existing "default" ruleset would 422, plus
  `master`-branch handling.

Closes #86

## Gotchas

- **`--add-readme` is load-bearing.** `github_branch_default` can only
  point at an existing branch, so applying against an empty repo fails
  setting the default to `main`. Seeding an initial commit is what makes
  the first apply clean — much of why bare out-of-band creates went
  sideways before.
- **Net-new imports the repository only**, not the ruleset — a fresh repo
  has none, so the module creates it. Ruleset import is the adopt-existing
  422 case only.
- No committed classification table: the skill derives it live from the
  module + `repositories.tf` each run, keeping the code the single source
  of truth (and sibling stacks like dungeon-studio #76 get surveyed free).
- First `.claude/` content here, but `REUSE.toml` already annotates
  `.claude/**` — no SPDX headers needed, REUSE passes.

## Verification

- `pre-commit` on `SKILL.md` + `CLAUDE.md` passes (markdownlint, REUSE;
  Terraform hooks skip — no `.tf`).
- Cross-checked the front-loaded failure modes against the existing
  adoption imports in `repositories.tf` (zellij-claude-pair 403; three
  colliding "default" rulesets, 422).