### PR TITLE
Query GCP metrics and audit logs from Grafana via data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Supporting how-tos:
 - [docs/how-to/create-deployer-github-app.md](docs/how-to/create-deployer-github-app.md)
 - [docs/how-to/create-git-sync-github-app.md](docs/how-to/create-git-sync-github-app.md)
 - [docs/how-to/create-grafana-git-sync-token.md](docs/how-to/create-grafana-git-sync-token.md)
+- [docs/how-to/connect-grafana-to-gcp.md](docs/how-to/connect-grafana-to-gcp.md)
 - [docs/how-to/create-web-analytics-site.md](docs/how-to/create-web-analytics-site.md)
 
 ## Support and contributions

--- a/docs/how-to/connect-grafana-to-gcp.md
+++ b/docs/how-to/connect-grafana-to-gcp.md
@@ -1,0 +1,54 @@
+<!-- SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com> -->
+<!-- SPDX-License-Identifier: MIT -->
+
+# Connect Grafana Cloud to GCP metrics and audit logs
+
+Grafana Cloud queries GCP directly at dashboard and alert time through a
+read-only service account — no logs or metrics are ingested. The Cloud
+Monitoring data source surfaces metrics, and a log-based metric over the
+Data Access audit logs powers audit alerting (the Cloud Logging query
+language has no Grafana alerting support, so alerts ride the counter).
+
+## Prerequisites
+
+- `just bootstrap` applied — creates the `grafana-gcp-reader` service
+  account, its key, and the `grafana-gcp-reader-key` Secret Manager
+  secret.
+- `terraform/alunduil` applied — creates the `gcp-cloud-monitoring` data
+  source and the `audit-data-access` log-based metric.
+- `gcloud`, `jq`, and `curl` available, authenticated as an identity that
+  can read the two secrets (project owner).
+
+## Set the data source credential
+
+The service-account key is set through the Grafana API rather than
+Terraform so it never enters the alunduil state:
+
+```sh
+scripts/set-grafana-gcp-credentials.sh
+```
+
+Confirm the data source authenticates: in Grafana, **Connections → Data
+sources → GCP Cloud Monitoring → Save & test**.
+
+## Create the audit alert
+
+1. **Alerting → Alert rules → New alert rule.**
+2. Query the **GCP Cloud Monitoring** data source for the metric
+   `logging.googleapis.com/user/audit-data-access`, aligned as a rate.
+3. Set the condition to fire when the count is above `0` over the
+   evaluation window, and attach your notification policy.
+
+## Validate
+
+Generate a synthetic Data Access event and confirm it lands:
+
+```sh
+gcloud secrets versions access latest \
+  --secret=grafana-provisioner-token --project=alunduil >/dev/null
+```
+
+Within a minute the `audit-data-access` metric increments in the Cloud
+Monitoring data source and the alert transitions to firing. The event
+still lands in Cloud Logging's `_Default`/`_Required` buckets — the data
+source reads, it does not divert.

--- a/scripts/set-grafana-gcp-credentials.sh
+++ b/scripts/set-grafana-gcp-credentials.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+set -euo pipefail
+
+# Sets the read-only GCP service-account key on the Grafana Cloud data sources
+# that query GCP live (Cloud Monitoring, and later Cloud Logging). The key is set
+# through the Grafana API rather than Terraform so it never lands in the
+# bucket-readable alunduil state; the key and the Grafana API token are both read
+# from Secret Manager and never written to disk. Run once after the data source
+# exists (bootstrap + terraform/alunduil apply) and again on key rotation.
+#
+# Usage: scripts/set-grafana-gcp-credentials.sh [datasource-uid ...]
+
+PROJECT_ID="${PROJECT_ID:-alunduil}"
+GRAFANA_URL="${GRAFANA_URL:-https://alunduil.grafana.net}"
+KEY_SECRET="${KEY_SECRET:-grafana-gcp-reader-key}"
+TOKEN_SECRET="${TOKEN_SECRET:-grafana-provisioner-token}"
+
+datasource_uids=("$@")
+if [[ ${#datasource_uids[@]} -eq 0 ]]; then
+  datasource_uids=(gcp-cloud-monitoring)
+fi
+
+key_json="$(gcloud secrets versions access latest --secret="${KEY_SECRET}" --project="${PROJECT_ID}")"
+grafana_token="$(gcloud secrets versions access latest --secret="${TOKEN_SECRET}" --project="${PROJECT_ID}")"
+private_key="$(jq -r '.private_key' <<<"${key_json}")"
+
+for uid in "${datasource_uids[@]}"; do
+  current="$(curl -fsS -H "Authorization: Bearer ${grafana_token}" \
+    "${GRAFANA_URL}/api/datasources/uid/${uid}")"
+
+  # Only touch secureJsonData; Terraform owns the non-secret jsonData.
+  updated="$(jq --arg pk "${private_key}" '.secureJsonData = {privateKey: $pk}' <<<"${current}")"
+
+  curl -fsS -X PUT \
+    -H "Authorization: Bearer ${grafana_token}" \
+    -H "Content-Type: application/json" \
+    -d "${updated}" \
+    "${GRAFANA_URL}/api/datasources/uid/${uid}" >/dev/null
+
+  echo "Set GCP credential on Grafana data source '${uid}'."
+done

--- a/terraform/alunduil/gcp_observability.tf
+++ b/terraform/alunduil/gcp_observability.tf
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# Grafana Cloud queries GCP directly at dashboard/alert time rather than
+# ingesting into Loki/Prometheus: for this personal infrastructure the audit-log
+# volume is tiny and a live-query data source avoids standing up a Pub/Sub +
+# collector pipeline. The read-only identity and its key live in the bootstrap
+# layer (grafana_gcp_reader.tf); the key is injected here out of band by
+# scripts/set-grafana-gcp-credentials.sh so it never enters this layer's
+# bucket-readable state.
+resource "grafana_data_source" "gcp_cloud_monitoring" {
+  type = "stackdriver"
+  name = "GCP Cloud Monitoring"
+  uid  = "gcp-cloud-monitoring"
+
+  json_data_encoded = jsonencode({
+    authenticationType = "jwt"
+    defaultProject     = local.bootstrap.project_id
+    clientEmail        = local.bootstrap.grafana_gcp_reader_email
+    tokenUri           = "https://oauth2.googleapis.com/token"
+  })
+
+  lifecycle {
+    # privateKey is set out of band from Secret Manager, so ignore the secure
+    # payload — otherwise each apply would send an empty value and wipe it.
+    ignore_changes = [secure_json_data_encoded]
+  }
+}
+
+# Log-based metric counting the Data Access audit events enabled in #83 (storage
+# reads/writes and Secret Manager access). The Cloud Logging query language has
+# no Grafana alerting support, so audit alerting rides this counter through the
+# Cloud Monitoring data source (metric type logging.googleapis.com/user/<name>)
+# instead of alerting on log lines directly.
+resource "google_logging_metric" "audit_data_access" {
+  name   = "audit-data-access"
+  filter = "logName=\"projects/${local.bootstrap.project_id}/logs/cloudaudit.googleapis.com%2Fdata_access\""
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+    unit        = "1"
+  }
+
+  depends_on = [google_project_service.logging]
+}

--- a/terraform/alunduil/project.tf
+++ b/terraform/alunduil/project.tf
@@ -14,3 +14,17 @@ resource "google_project_service" "storage_component" {
 
   disable_on_destroy = false
 }
+
+# Kept enabled because the audit log-based metric in gcp_observability.tf depends
+# on it; moved out of services_to_disable.tf now that a managed resource uses it.
+resource "google_project_service" "logging" {
+  project = local.bootstrap.project_id
+  service = "logging.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+moved {
+  from = google_project_service.legacy["logging.googleapis.com"]
+  to   = google_project_service.logging
+}

--- a/terraform/alunduil/services_to_disable.tf
+++ b/terraform/alunduil/services_to_disable.tf
@@ -20,7 +20,6 @@ resource "google_project_service" "legacy" {
     "smartdevicemanagement.googleapis.com", # Nest / Google Home
 
     # Observability — GCP often re-enables automatically
-    "logging.googleapis.com",
     "monitoring.googleapis.com",
 
     # Compute Engine and related

--- a/terraform/bootstrap/grafana_gcp_reader.tf
+++ b/terraform/bootstrap/grafana_gcp_reader.tf
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2026 Alex Brandt <alunduil@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# Read-only service account Grafana Cloud authenticates as to query GCP directly
+# at dashboard/alert time — Cloud Monitoring for metrics, Cloud Logging for logs.
+# No data is ingested; the terraform/alunduil layer wires the Grafana data
+# sources that use this identity.
+#
+# The key lives here rather than in the alunduil layer because a Grafana data
+# source stores its credential in Terraform state (there is no write-only field
+# like the Git Sync App key uses), and Grafana Cloud offers no keyless/workload-
+# identity path for this data source. Keeping the key in the IAM-isolated
+# bootstrap state — never in the bucket-readable alunduil state — preserves the
+# per-secret isolation the rest of this layer relies on. The credential reaches
+# Grafana out of band from Secret Manager (scripts/set-grafana-gcp-credentials.sh),
+# so it never enters the alunduil state.
+resource "google_service_account" "grafana_gcp_reader" {
+  project      = google_project.env.project_id
+  account_id   = "grafana-gcp-reader"
+  display_name = "Grafana GCP Reader"
+  description  = "Read-only identity Grafana Cloud uses to query Cloud Monitoring and Cloud Logging"
+
+  depends_on = [google_project_service.iam]
+}
+
+resource "google_project_iam_member" "grafana_gcp_reader" {
+  for_each = toset([
+    "roles/monitoring.viewer",
+    "roles/logging.viewer",
+    "roles/logging.viewAccessor",
+  ])
+
+  project = google_project.env.project_id
+  role    = each.key
+  member  = "serviceAccount:${google_service_account.grafana_gcp_reader.email}"
+}
+
+resource "google_service_account_key" "grafana_gcp_reader" {
+  service_account_id = google_service_account.grafana_gcp_reader.name
+}
+
+resource "google_secret_manager_secret" "grafana_gcp_reader_key" {
+  project   = google_project.env.project_id
+  secret_id = "grafana-gcp-reader-key"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret_version" "grafana_gcp_reader_key" {
+  secret      = google_secret_manager_secret.grafana_gcp_reader_key.id
+  secret_data = base64decode(google_service_account_key.grafana_gcp_reader.private_key)
+}

--- a/terraform/bootstrap/outputs.tf
+++ b/terraform/bootstrap/outputs.tf
@@ -76,3 +76,15 @@ output "grafana_git_sync_app_private_key_secret" {
   description = "Secret Manager short name holding the Git Sync GitHub App private key; fetched at plan and apply time via `gcloud secrets versions access`"
   sensitive   = false
 }
+
+output "grafana_gcp_reader_email" {
+  value       = google_service_account.grafana_gcp_reader.email
+  description = "Email of the read-only SA Grafana Cloud uses to query GCP; consumed by terraform/alunduil/ as the data-source clientEmail"
+  sensitive   = false
+}
+
+output "grafana_gcp_reader_key_secret" {
+  value       = google_secret_manager_secret.grafana_gcp_reader_key.secret_id
+  description = "Secret Manager short name holding the Grafana GCP reader SA key; read out of band by scripts/set-grafana-gcp-credentials.sh to set the Grafana data-source credential"
+  sensitive   = false
+}

--- a/terraform/bootstrap/published_outputs.tf
+++ b/terraform/bootstrap/published_outputs.tf
@@ -18,5 +18,6 @@ resource "google_storage_bucket_object" "published_outputs" {
     grafana_stack_id                     = data.grafana_cloud_stack.this.id
     grafana_git_sync_app_id              = var.grafana_git_sync_app_id
     grafana_git_sync_app_installation_id = var.grafana_git_sync_app_installation_id
+    grafana_gcp_reader_email             = google_service_account.grafana_gcp_reader.email
   })
 }

--- a/terraform/bootstrap/service_account_github_deployer_ro.tf
+++ b/terraform/bootstrap/service_account_github_deployer_ro.tf
@@ -18,6 +18,8 @@ resource "google_project_iam_custom_role" "github_deployer_ro_planner" {
   description = "Least-privilege read role for terraform plan in CI"
 
   permissions = [
+    "logging.logMetrics.get",
+    "logging.logMetrics.list",
     "resourcemanager.projects.get",
     "serviceusage.services.get",
     "serviceusage.services.list",

--- a/terraform/bootstrap/service_account_github_deployer_rw.tf
+++ b/terraform/bootstrap/service_account_github_deployer_rw.tf
@@ -19,6 +19,11 @@ resource "google_project_iam_custom_role" "github_deployer_rw_applier" {
   description = "Least-privilege role for terraform apply in CI"
 
   permissions = [
+    "logging.logMetrics.create",
+    "logging.logMetrics.delete",
+    "logging.logMetrics.get",
+    "logging.logMetrics.list",
+    "logging.logMetrics.update",
     "resourcemanager.projects.get",
     "serviceusage.services.disable",
     "serviceusage.services.enable",


### PR DESCRIPTION
## Summary

Grafana Cloud now surfaces GCP metrics and Data Access audit logs by
querying GCP live through a read-only service account, rather than
ingesting into Loki. For this personal infrastructure the audit-log volume
is tiny, so a live-query data source avoids a Pub/Sub topic, subscription,
and always-on Alloy collector just to forward a trickle of events. Audit
alerting rides a log-based metric through Cloud Monitoring, since Grafana
has no alerting for the Cloud Logging query language.

Closes #88.

## Gotchas

- **Two-phase apply.** Bootstrap must apply first — it adds the
  `grafana-gcp-reader` SA and the `logging.logMetrics` permissions to the
  deployer roles. Merging before a `just bootstrap` run fails the alunduil
  CI apply on missing permissions.
- **The data-source credential is set out of band, not by Terraform.**
  `grafana_data_source` has no write-only field and Grafana Cloud offers no
  keyless path, so the key stays in the IAM-isolated bootstrap state and is
  injected via the Grafana API (`scripts/set-grafana-gcp-credentials.sh`).
  `secure_json_data_encoded` is `ignore_changes`d so applies don't wipe it.
  Consequence: the audit alert is created via the how-to, not TF.
- **`logging.googleapis.com` moves layers via a `moved` block** (from the
  `services_to_disable` set to a kept service) now that the log-based metric
  depends on it — the plan should show a state move, not destroy/recreate.
- **Deferred, deliberately.** The Cloud Logging data source (Enterprise-tier
  plugin) and the declarative alert rule need live-stack/tier validation, so
  they're in #228. The bootstrap-scope creep this adds is tracked in #229.

## Verification

- `pre-commit` passed on all changed files: terraform fmt + validate (both
  layers), ShellCheck, shfmt, reuse lint, detect-secrets, markdownlint.
- Not validated against the live stack (CI runs the plan; I don't): the
  data-source `jsonData` and the log-based-metric filter are syntactically
  valid but unexercised — worth a look in the plan comment before merge.